### PR TITLE
feat: add Svelte task prompt

### DIFF
--- a/src/lib/mcp/index.ts
+++ b/src/lib/mcp/index.ts
@@ -89,6 +89,46 @@ server.tool(
 	},
 );
 
+server.prompt(
+	{
+		name: 'svelte-task-prompt',
+		title: 'Svelte Task Prompt',
+		description:
+			'Use this Prompt to ask for any svelte related task. It will automatically instruct the LLM on how to best use the autofixer and how to query for documentation pages.',
+		schema: v.object({
+			task: v.pipe(v.string(), v.description('The task to be performed')),
+		}),
+	},
+	async ({ task }) => {
+		// TODO: implement logic to fetch the available docs paths to return in the prompt
+		const available_docs: string[] = [];
+
+		return {
+			messages: [
+				{
+					role: 'user',
+					content: {
+						type: 'text',
+						text: `You are a Svelte expert tasked to build components and utilities for Svelte developers. If you need documentation for anything related to Svelte you can invoke the tool \`get_documentation\` with one of the following paths:
+<available-docs-paths>						
+${JSON.stringify(available_docs, null, 2)}
+</available-docs-paths>
+
+Every time you write a Svelte component or a Svelte module you MUST invoke the \`svelte-autofixer\` tool providing the code. The tool will return a list of issues or suggestions. If there are any issues or suggestions you MUST fix them and call the tool again with the updated code. You MUST keep doing this until the tool returns no issues or suggestions. Only then you can return the code to the user.
+
+This is the task you will work on:
+
+<task>
+${task}
+</task>
+`,
+					},
+				},
+			],
+		};
+	},
+);
+
 export const http_transport = new HttpTransport(server, {
 	cors: true,
 });


### PR DESCRIPTION
This adds a prompt that instructs the LLM about the available docs sections 

<img width="500" height="696" alt="image" src="https://github.com/user-attachments/assets/458d3cce-de3c-404c-8794-5420805c1230" />

and how to better use the autofixer.

We can always iterate over the prompt, but it feels like an easy win for now.