### PR TITLE
chore: add eslint rules for naming convention and function declaration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,10 +7,10 @@ import { fileURLToPath } from 'node:url';
 import ts from 'typescript-eslint';
 import svelteConfig from './svelte.config.js';
 
-const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
+const gitignore_path = fileURLToPath(new URL('./.gitignore', import.meta.url));
 
 export default ts.config(
-	includeIgnoreFile(gitignorePath),
+	includeIgnoreFile(gitignore_path),
 	js.configs.recommended,
 	...ts.configs.recommended,
 	...svelte.configs.recommended,
@@ -24,6 +24,15 @@ export default ts.config(
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
 			'no-undef': 'off',
+			'@typescript-eslint/naming-convention': [
+				'error',
+				{
+					selector: ['variableLike'],
+					format: ['snake_case', 'UPPER_CASE'],
+					leadingUnderscore: 'allow',
+				},
+			],
+			'func-style': ['error', 'declaration', { allowTypeAnnotation: true }],
 		},
 	},
 	{


### PR DESCRIPTION
Adding a couple of eslint rules for naming conventions and function declarations