### PR TITLE
fix: close SSE stream immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ pnpm dev
 
 1. Set the VOYAGE_API_KEY for embeddings support
 
+> [!NOTE]
+> Currently to prevent having a bunch of Timeout logs on vercel we shut down the SSE channel immediately. This means that we can't use `server.log` and we are not sending `list-changed` notifications. We can use elicitation and sampling since those are sent on the same stream of the POST request
+
 ### Local dev tools
 
 #### MCP inspector

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",
 		"@tmcp/adapter-valibot": "^0.1.4",
-		"@tmcp/transport-http": "^0.6.0",
+		"@tmcp/transport-http": "^0.6.1",
 		"@tmcp/transport-stdio": "^0.1.3",
 		"@typescript-eslint/parser": "^8.43.0",
 		"eslint": "^9.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.1.4
         version: 0.1.4(tmcp@1.12.2(typescript@5.9.2))(valibot@1.1.0(typescript@5.9.2))
       '@tmcp/transport-http':
-        specifier: ^0.6.0
-        version: 0.6.0(tmcp@1.12.2(typescript@5.9.2))
+        specifier: ^0.6.1
+        version: 0.6.1(tmcp@1.12.2(typescript@5.9.2))
       '@tmcp/transport-stdio':
         specifier: ^0.1.3
         version: 0.1.3(tmcp@1.12.2(typescript@5.9.2))
@@ -1313,13 +1313,13 @@ packages:
       tmcp: ^1.10.2
       valibot: ^1.1.0
 
-  '@tmcp/session-manager@0.1.1':
-    resolution: {integrity: sha512-L4kuE5p+L34SzCkdF/dKEPRjOybPnjmNIdv3Vejpnj1BU8WIabBtKT4VQCFxGnO2RVtflh3Rg+OxBOe8igswRA==}
+  '@tmcp/session-manager@0.1.2':
+    resolution: {integrity: sha512-hNkEeMt7/CdD8JdjPXMlIv5OMPTp5LnBqeo1Tb/AXcm31DpgwlNbf4voJ3CeWxWAZPPZ/MgHZ682TtgGhsvXiw==}
 
-  '@tmcp/transport-http@0.6.0':
-    resolution: {integrity: sha512-/K6J/pzwGQ46sfMFPywLS73nnDCJs0Vg7TlyZ0CUF8hLYky28U85u4Vf8T/I+e4D6N2hL32rPymQpng9UKRNrw==}
+  '@tmcp/transport-http@0.6.1':
+    resolution: {integrity: sha512-DENjAfXwzDQFCXu8HhJynLpDZZMmhat3g2OR1hZA5xpXIS2tI3oC5pdEQMFa/UyHAdgHfcJyUPQeQcjBHqIZ6A==}
     peerDependencies:
-      tmcp: ^1.11.0
+      tmcp: ^1.12.2
 
   '@tmcp/transport-stdio@0.1.3':
     resolution: {integrity: sha512-xRQ5+M2E6MXJXt0aw26ezoV3r5navrhvg545LkaWg5SjD7ovITLUiCJ5fgP7L5kWeb9GpEiFqxhqFkli+7tz6A==}
@@ -4140,11 +4140,11 @@ snapshots:
       tmcp: 1.12.2(typescript@5.9.2)
       valibot: 1.1.0(typescript@5.9.2)
 
-  '@tmcp/session-manager@0.1.1': {}
+  '@tmcp/session-manager@0.1.2': {}
 
-  '@tmcp/transport-http@0.6.0(tmcp@1.12.2(typescript@5.9.2))':
+  '@tmcp/transport-http@0.6.1(tmcp@1.12.2(typescript@5.9.2))':
     dependencies:
-      '@tmcp/session-manager': 0.1.1
+      '@tmcp/session-manager': 0.1.2
       tmcp: 1.12.2(typescript@5.9.2)
 
   '@tmcp/transport-stdio@0.1.3(tmcp@1.12.2(typescript@5.9.2))':

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,20 @@
 import { http_transport } from '$lib/mcp';
 
 export async function handle({ event, resolve }) {
-	return (await http_transport.respond(event.request)) ?? resolve(event);
+	const mcp_response = await http_transport.respond(event.request);
+	// we are deploying on vercel the SSE connection will timeout after 5 minutes...for
+	// the moment we are not sending back any notifications (logs, or list changed notifications)
+	// so it's a waste of resources to keep a connection open that will error
+	// after 5 minutes making the logs dirty. For this reason if we have a response from
+	// the MCP server and it's a GET request we just return an empty response (it has to be
+	// 200 or the MCP client will complain)
+	if (mcp_response && event.request.method === 'GET') {
+		try {
+			await mcp_response.body?.cancel();
+		} catch {
+			// ignore
+		}
+		return new Response('', { status: 200 });
+	}
+	return mcp_response ?? resolve(event);
 }


### PR DESCRIPTION
Right now, the SSE stream sits basically unused (since it's really only used for list changed notification and logging, both of which we don't even have in the capabilities). But since we are hosting on Vercel, it times out after 300 seconds, leaving a nasty log in the observability panel.

Doing this will immediately close the stream and return an empty string (or the MCP inspector will yell at us) so that we don't waste Vercel resources and we don't have nasty logs.

The downside is obviously that if, in the future, we want to send notifications or logs, we have to remember to re-enable it.

Btw, testing this I:

1. Found a bug in the session manager implementation that I fixed (hence the upgrade dependency)
2. Realised that, given we only support HTTP streaming, we can actually use Elicitation and Sampling since those are sent back on the same stream of the POST request. We might not even need the Redis instance since with Fluid Compute, it should go to the same lambda, but we'll see if we ever go that route.

I would say this is good for the moment, but I want to hear if anybody is against it.