### PR TITLE
fix: check effect.pre in assign-in-effect

### DIFF
--- a/.changeset/cool-tips-explain.md
+++ b/.changeset/cool-tips-explain.md
@@ -1,5 +1,5 @@
 ---
-"@sveltejs/mcp": patch
+'@sveltejs/mcp': patch
 ---
 
 fix: check effect.pre in assign-in-effect

--- a/.changeset/cool-tips-explain.md
+++ b/.changeset/cool-tips-explain.md
@@ -1,0 +1,5 @@
+---
+"@sveltejs/mcp": patch
+---
+
+fix: check effect.pre in assign-in-effect

--- a/packages/mcp-server/src/mcp/autofixers/add-autofixers-issues.test.ts
+++ b/packages/mcp-server/src/mcp/autofixers/add-autofixers-issues.test.ts
@@ -61,7 +61,7 @@ describe('add_autofixers_issues', () => {
 				<script>
 					const count = ${init}(0);
 				</script>
-				
+
 				<button onclick={() => count = 43}>Increment</button>
 				`);
 
@@ -74,7 +74,7 @@ describe('add_autofixers_issues', () => {
 				const content = run_autofixers_on_code(`
 				<script>
 					const count = 0;
-					
+
 					$effect(() => {
 						count = 43;
 					});
@@ -89,7 +89,7 @@ describe('add_autofixers_issues', () => {
 				const content = run_autofixers_on_code(`
 				<script>
 					let count = ${init}(0);
-					
+
 					$effect(() => {
 						count++;
 					});
@@ -105,8 +105,24 @@ describe('add_autofixers_issues', () => {
 				const content = run_autofixers_on_code(`
 				<script>
 					let count = ${init}({ value: 0 });
-					
+
 					$effect(() => {
+						count.value = 42;
+					});
+				</script>
+				`);
+
+				expect(content.suggestions).toContain(
+					'The stateful variable "count" is assigned inside an $effect which is generally consider a malpractice. Consider using $derived if possible.',
+				);
+			});
+
+			it(`should add a suggestion for variables that are mutated within an effect.pre`, () => {
+				const content = run_autofixers_on_code(`
+				<script>
+					let count = ${init}({ value: 0 });
+
+					$effect.pre(() => {
 						count.value = 42;
 					});
 				</script>

--- a/packages/mcp-server/src/mcp/autofixers/visitors/assign-in-effect.ts
+++ b/packages/mcp-server/src/mcp/autofixers/visitors/assign-in-effect.ts
@@ -11,19 +11,11 @@ function run_if_in_effect(
 ) {
 	const in_effect = path.findLast(
 		(node) =>
-			node.type === 'CallExpression' &&
-			node.callee.type === 'Identifier' &&
-			node.callee.name === '$effect',
+			node.type === 'CallExpression' && state.parsed.is_rune(node, ['$effect', '$effect.pre']),
 	);
 
-	if (
-		in_effect &&
-		in_effect.type === 'CallExpression' &&
-		(in_effect.callee.type === 'Identifier' || in_effect.callee.type === 'MemberExpression')
-	) {
-		if (state.parsed.is_rune(in_effect, ['$effect', '$effect.pre'])) {
-			to_run();
-		}
+	if (in_effect) {
+		to_run();
 	}
 }
 


### PR DESCRIPTION
It seems like the intention here was to check `$effect` _and_
`$effect.pre`, but the condition (`in_effect`) was filtering those out.
The `is_rune` helper already does the same checks, so we can just remove
the ones here and delegate to that.

If we don't want to report on `effect.pre`, i can rework this to  just remove the `'$effect.pre'` from the list of runes.
