### PR TITLE
feat: publish to registry

### DIFF
--- a/.changeset/sad-ways-pay.md
+++ b/.changeset/sad-ways-pay.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/mcp': minor
+---
+
+feat: publish to registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Publish to MCP Registry
+        if: steps.changesets.outputs.published == 'true'
+        working-directory: packages/mcp-stdio
+        run: |
+          # Download MCP Publisher pinned to v1.2.3
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/download/v1.2.3/mcp-publisher_1.2.3_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+          # Login using GitHub OIDC
+          ./mcp-publisher login github-oidc
+
+          # Publish to MCP Registry
+          ./mcp-publisher publish

--- a/packages/mcp-stdio/package.json
+++ b/packages/mcp-stdio/package.json
@@ -3,6 +3,7 @@
 	"version": "0.0.3",
 	"type": "module",
 	"license": "MIT",
+	"mcpName": "io.github.sveltejs/svelte",
 	"homepage": "https://github.com/sveltejs/mcp#readme",
 	"bugs": {
 		"url": "https://github.com/sveltejs/mcp/issues"

--- a/packages/mcp-stdio/server.json
+++ b/packages/mcp-stdio/server.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+	"name": "io.github.sveltejs/svelte",
+	"description": "The official Svelte MCP server providing docs and autofixing tools for Svelte development",
+	"repository": {
+		"id": "1054419133",
+		"url": "https://github.com/sveltejs/mcp",
+		"subfolder": "packages/mcp-stdio",
+		"source": "github"
+	},
+	"version": "0.1.0",
+	"websiteUrl": "https://svelte.dev/docs/mcp/overview",
+	"packages": [
+		{
+			"registryType": "npm",
+			"identifier": "@sveltejs/mcp",
+			"version": "0.1.0",
+			"runtimeHint": "npx",
+			"transport": {
+				"type": "stdio"
+			}
+		}
+	],
+	"remotes": [
+		{
+			"url": "https://mcp.svelte.dev/mcp",
+			"type": "streamable-http"
+		}
+	]
+}


### PR DESCRIPTION
Partially address #42 

Something to figure out:

1. Currently, I fetch a pinned version of `mcp-publisher`...they suggest fetching the latest, but that feels like an absurd safety hazard. Should we find a way to automate the update of that?
2. Similarly, we should technically find a way to keep the release version in the package.json in sync with the version in `server.json`...can changesets do that? Another option would be to write a custom step in the `release.yml` workflow that pushes the change in the open PR, but I currently have no idea how to do it.
3. This also means that we only push to the registry when we publish a new version of the package...I think this is probably fine, but since we release the remote one on merge, it will mean the two will be slightly out of sync. Not a big deal imho.
4. We could technically use svelte.dev as the name instead of io.github.sveltejs, but we need to add a TXT DNS record. Not a big deal, we just need to decide if we want to do it.