### PR TITLE
Fix CLI command syntax for Claude Code and Gemini CLI

### DIFF
--- a/documentation/docs/20-setup/20-local-setup.md
+++ b/documentation/docs/20-setup/20-local-setup.md
@@ -15,7 +15,7 @@ Here's how to set it up in some common MCP clients:
 To include the local MCP version in Claude Code, simply run the following command:
 
 ```bash
-claude mcp add -t stdio -s [scope] svelte npx -y @sveltejs/mcp
+claude mcp add -t stdio -s [scope] svelte -- npx -y @sveltejs/mcp
 ```
 
 The `[scope]` must be `user`, `project` or `local`.
@@ -50,7 +50,7 @@ args = ["-y", "@sveltejs/mcp"]
 To include the local MCP version in Gemini CLI, simply run the following command:
 
 ```bash
-gemini mcp add -t stdio -s [scope] svelte npx -y @sveltejs/mcp
+gemini mcp add -t stdio -s [scope] svelte -- npx -y @sveltejs/mcp
 ```
 
 The `[scope]` must be `user`, `project` or `local`.


### PR DESCRIPTION
The `-y` option was incorrectly parsed as a CLI option instead of being passed to npx. Fixed by adding `--` separator before the npx command.