### PR TITLE
Correct JSON structure in remote setup documentation

### DIFF
--- a/documentation/docs/20-setup/30-remote-setup.md
+++ b/documentation/docs/20-setup/30-remote-setup.md
@@ -105,13 +105,13 @@ It will open a file with your MCP servers where you can add the following config
 
 ```json
 {
-   "mcpServers": {
-      "svelte": {
-         "type": "http",
-         "url": "https://mcp.svelte.dev/mcp",
-         "tools": ["*"]
-      }
-   }
+	"mcpServers": {
+		"svelte": {
+			"type": "http",
+			"url": "https://mcp.svelte.dev/mcp",
+			"tools": ["*"]
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
Fixed JSON syntax for mcpServers configuration.