### PR TITLE
chore: add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: svelte


### PR DESCRIPTION
I was looking through which repos in our org has a FUNDING.yml file and noticed this one didn’t have one.