### PR TITLE
fix: add `async` parameter to `svelte-autofixer`

### DIFF
--- a/.changeset/icy-queens-greet.md
+++ b/.changeset/icy-queens-greet.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/mcp': patch
+---
+
+fix: add `async` parameter to `svelte-autofixer`

--- a/packages/mcp-server/src/mcp/autofixers/add-autofixers-issues.ts
+++ b/packages/mcp-server/src/mcp/autofixers/add-autofixers-issues.ts
@@ -8,6 +8,7 @@ export function add_autofixers_issues(
 	code: string,
 	desired_svelte_version: number,
 	filename = 'Component.svelte',
+	async = false,
 ) {
 	const parsed = parse(code, filename);
 
@@ -15,7 +16,7 @@ export function add_autofixers_issues(
 	for (const autofixer of Object.values(autofixers)) {
 		walk(
 			parsed.ast as unknown as Node,
-			{ output: content, parsed, desired_svelte_version },
+			{ output: content, parsed, desired_svelte_version, async },
 			autofixer,
 		);
 	}

--- a/packages/mcp-server/src/mcp/autofixers/add-compile-issues.ts
+++ b/packages/mcp-server/src/mcp/autofixers/add-compile-issues.ts
@@ -7,6 +7,7 @@ export function add_compile_issues(
 	code: string,
 	desired_svelte_version: number,
 	filename = 'Component.svelte',
+	async = false,
 ) {
 	let compile = compile_component;
 	const extension = extname(filename);
@@ -27,6 +28,7 @@ export function add_compile_issues(
 		filename: filename || 'Component.svelte',
 		generate: false,
 		runes: desired_svelte_version >= 5,
+		experimental: { async },
 	});
 
 	for (const warning of compilation_result.warnings) {

--- a/packages/mcp-server/src/mcp/autofixers/add-eslint-issues.ts
+++ b/packages/mcp-server/src/mcp/autofixers/add-eslint-issues.ts
@@ -51,7 +51,7 @@ function base_config(svelte_config: Config): ESLint.Options['baseConfig'] {
 	];
 }
 
-function get_linter(version: number) {
+function get_linter(version: number, async = false) {
 	if (version < 5) {
 		return (svelte_4_linter ??= new ESLint({
 			overrideConfigFile: true,
@@ -67,6 +67,7 @@ function get_linter(version: number) {
 		baseConfig: base_config({
 			compilerOptions: {
 				runes: true,
+				experimental: { async },
 			},
 		}),
 	}));
@@ -77,8 +78,9 @@ export async function add_eslint_issues(
 	code: string,
 	desired_svelte_version: number,
 	filename = 'Component.svelte',
+	async = false,
 ) {
-	const eslint = get_linter(desired_svelte_version);
+	const eslint = get_linter(desired_svelte_version, async);
 	const results = await eslint.lintText(code, { filePath: filename || './Component.svelte' });
 
 	for (const message of results[0]?.messages ?? []) {

--- a/packages/mcp-server/src/mcp/autofixers/visitors/index.ts
+++ b/packages/mcp-server/src/mcp/autofixers/visitors/index.ts
@@ -7,6 +7,7 @@ export type AutofixerState = {
 	output: { issues: string[]; suggestions: string[] };
 	parsed: ParseResult;
 	desired_svelte_version: number;
+	async?: boolean;
 };
 
 export type Autofixer = Visitors<Node | AST.SvelteNode, AutofixerState>;


### PR DESCRIPTION
I realized we were always compiling with async `false` which means people using async would get wrong issues from the autofixer.

This fixes that by introducing an `async` parameter to the autofixer.