### PR TITLE
docs: update zed docs to use svelte-mcp extension

### DIFF
--- a/documentation/docs/20-setup/20-local-setup.md
+++ b/documentation/docs/20-setup/20-local-setup.md
@@ -110,6 +110,12 @@ It will open a file with your MCP servers where you can add the following config
 
 ## Zed
 
+Install the [Svelte MCP Server extension](https://zed.dev/extensions/svelte-mcp).
+
+<details>
+
+<summary>Configure Manually</summary>
+
 - Open the command palette
 - Search and select "agent:open settings"
 - In settings panel look for `Model Context Protocol (MCP) Servers`
@@ -126,6 +132,8 @@ It will open a popup with MCP server config where you can add the following conf
 	}
 }
 ```
+
+</details>
 
 ## Other clients
 


### PR DESCRIPTION
<img width="1195" height="309" alt="image" src="https://github.com/user-attachments/assets/c37ca6f4-385f-4363-bc42-5ded560e2afe" />

<img width="1206" height="1175" alt="image" src="https://github.com/user-attachments/assets/4e3369d2-3685-4b7c-8f18-e163fe2d316d" />
