### PR TITLE
chore: add initialize analytics event

### DIFF
--- a/apps/mcp-remote/src/hooks.server.ts
+++ b/apps/mcp-remote/src/hooks.server.ts
@@ -24,8 +24,8 @@ export async function handle({ event, resolve }) {
 		// only add analytics in production
 		track: dev
 			? undefined
-			: async (session_id, event, slug) => {
-					await track(event, { session_id, ...(slug ? { slug } : {}) });
+			: async (session_id, event, extra) => {
+					await track(event, { session_id, ...(extra ? { extra } : {}) });
 				},
 	});
 	// we are deploying on vercel the SSE connection will timeout after 5 minutes...for

--- a/packages/mcp-server/src/mcp/index.ts
+++ b/packages/mcp-server/src/mcp/index.ts
@@ -26,7 +26,7 @@ export const server = new McpServer(
 	},
 ).withContext<{
 	db: LibSQLDatabase<Schema>;
-	track?: (sessionId: string, event: string, slug?: string) => Promise<void>;
+	track?: (sessionId: string, event: string, extra?: string) => Promise<void>;
 }>();
 
 export type SvelteMcp = typeof server;
@@ -34,3 +34,8 @@ export type SvelteMcp = typeof server;
 setup_tools(server);
 setup_resources(server);
 setup_prompts(server);
+
+server.on('initialize', async ({ clientInfo: client_info }) => {
+	if (!server.ctx.custom?.track || !server.ctx.sessionId) return;
+	server.ctx.custom.track(server.ctx.sessionId, 'initialize', client_info.name);
+});


### PR DESCRIPTION
I forgot to add the most useful analytics event: `initialize` will literally tell us how many times people connect with our MCP server. I also stored the `clientInfo.name` so we can get a sense of the MCP client they are using (obviously all of this is still anonymous).