### PR TITLE
Update valid scope options in remote setup documentation for Gemini CLI

### DIFF
--- a/documentation/docs/20-setup/30-remote-setup.md
+++ b/documentation/docs/20-setup/30-remote-setup.md
@@ -42,7 +42,7 @@ To use the remote MCP server with Gemini CLI, simply run the following command:
 gemini mcp add -t http -s [scope] svelte https://mcp.svelte.dev/mcp
 ```
 
-The `[scope]` must be `user`, `project` or `local`.
+The `[scope]` must be `user` or `project`.
 
 ## OpenCode
 


### PR DESCRIPTION
## Removed `local` from valid scope in Gemini CLI

As per [documentation](https://geminicli.com/docs/tools/mcp-server/#adding-a-server-gemini-mcp-add) scope argument only has two possible scopes: `user` or `project`.
