### PR TITLE
feat: add ANTHROPIC_BASE_URL to support self-hosted deployments

### DIFF
--- a/packages/mcp-server/.env.example
+++ b/packages/mcp-server/.env.example
@@ -1,2 +1,6 @@
 # Anthropic API Key from: https://console.anthropic.com/
 ANTHROPIC_API_KEY=your_api_key_here
+
+# Optional: Custom Anthropic API base URL for self-hosted or enterprise deployments
+# Defaults to https://api.anthropic.com/v1 if not specified
+# ANTHROPIC_BASE_URL=https://custom-api.example.com/v1

--- a/packages/mcp-server/scripts/generate-summaries.ts
+++ b/packages/mcp-server/scripts/generate-summaries.ts
@@ -74,6 +74,9 @@ async function main() {
 		process.exit(1);
 	}
 
+	// Get base URL (optional, defaults to Anthropic's API)
+	const base_url = process.env.ANTHROPIC_BASE_URL;
+
 	// Get all sections
 	console.log('📚 Fetching documentation sections...');
 	let sections = await get_sections();
@@ -121,7 +124,7 @@ async function main() {
 
 	// Initialize Anthropic client
 	console.log('🤖 Initializing Anthropic API...');
-	const anthropic = new AnthropicProvider('claude-sonnet-4-5-20250929', api_key);
+	const anthropic = new AnthropicProvider('claude-sonnet-4-5-20250929', api_key, base_url);
 
 	// Prepare batch requests
 	console.log('📦 Preparing batch requests...');

--- a/packages/mcp-server/src/lib/anthropic.ts
+++ b/packages/mcp-server/src/lib/anthropic.ts
@@ -14,14 +14,20 @@ export class AnthropicProvider {
 	private apiKey: string;
 	name = 'Anthropic';
 
-	constructor(model_id: Model, api_key: string) {
+	constructor(model_id: Model, api_key: string, base_url: string = 'https://api.anthropic.com/v1') {
 		if (!api_key) {
 			throw new Error('ANTHROPIC_API_KEY is required');
 		}
 		this.apiKey = api_key;
-		this.client = new Anthropic({ apiKey: api_key, timeout: 1800000 });
 		this.modelId = model_id;
-		this.baseUrl = 'https://api.anthropic.com/v1';
+		// Remove trailing slash if present to prevent double slashes in URLs
+		this.baseUrl = base_url.replace(/\/$/, '');
+
+		this.client = new Anthropic({
+			apiKey: api_key,
+			timeout: 1800000,
+			baseURL: this.baseUrl,
+		});
 	}
 
 	get_client(): Anthropic {
@@ -108,8 +114,7 @@ export class AnthropicProvider {
 						error,
 					);
 					throw new Error(
-						`Failed to get batch status after ${max_retries} retries: ${
-							error instanceof Error ? error.message : String(error)
+						`Failed to get batch status after ${max_retries} retries: ${error instanceof Error ? error.message : String(error)
 						}`,
 					);
 				}


### PR DESCRIPTION
This adds the `ANTHROPIC_BASE_URL` as an ENV variable to support using self-hosted deployments that are compatible with Anthropic APIs. This is useful for users using Anthropic-compatible APIs like [those on Amazon Bedrock](https://aws.amazon.com/bedrock/anthropic/). 