### PR TITLE
fix: import `ts` files directly

### DIFF
--- a/.changeset/forty-lions-arrive.md
+++ b/.changeset/forty-lions-arrive.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/opencode': patch
+---
+
+fix: import `ts` files directly

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -2,8 +2,8 @@ import type { Plugin } from '@opencode-ai/plugin';
 import { readdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { agents } from './agents.js';
-import { get_mcp_config } from './config.js';
+import { agents } from './agents.ts';
+import { get_mcp_config } from './config.ts';
 
 const current_dir = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -1,5 +1,9 @@
 {
 	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"allowImportingTsExtensions": true,
+		"types": ["@types/node"]
+	},
 	"include": ["index.ts", "config.ts", "agents.ts", "scripts/*"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
Closes #189 

`opencode` recently changed from bun to node in some part and this broke the resolution. This should fix it (unfortunately it's a tentative)