### PR TITLE
Fix grammar in SKILL.md regarding derived variables

### DIFF
--- a/tools/skills/svelte-core-bestpractices/SKILL.md
+++ b/tools/skills/svelte-core-bestpractices/SKILL.md
@@ -27,7 +27,7 @@ $effect(() => {
 
 > [!NOTE] `$derived` is given an expression, _not_ a function. If you need to use a function (because the expression is complex, for example) use `$derived.by`.
 
-Deriveds are writable — you can assign to them, just like `$state`, except that they will re-evaluate when their expression changes.
+The derived variables are writable — you can assign to them, just like `$state`, except that they will re-evaluate when their expression changes.
 
 If the derived expression is an object or array, it will be returned as-is — it is _not_ made deeply reactive. You can, however, use `$state` inside `$derived.by` in the rare cases that you need this.
 


### PR DESCRIPTION
I am not sure if this matters, but because $derived is past-tense-ish, so 'deriveds' does sound right, but I suspect the aim was to say something, "derived [variables] are writable ...", but needed to add plurality to it, hence, 'deriveds', but, that does not sound right.

My suggestion is, adding, 'the', that is to say, "the derived [variables] are are writable ..."