### PR TITLE
fix: remove restrictive permissions from subagent

### DIFF
--- a/.changeset/fuzzy-dancers-deny.md
+++ b/.changeset/fuzzy-dancers-deny.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/opencode': patch
+---
+
+fix: remove restrictive permissions from subagent

--- a/packages/opencode/index.ts
+++ b/packages/opencode/index.ts
@@ -81,12 +81,7 @@ export const svelte_plugin: Plugin = async (ctx) => {
 						prompt: agent_data.prompt,
 						description: agent_data.description,
 						permission: {
-							bash: 'ask',
-							edit: 'allow',
-							webfetch: 'ask',
-						},
-						tools: {
-							[`${svelte_mcp_name}_*`]: true,
+							[`${svelte_mcp_name}_*`]: 'allow',
 						},
 					};
 


### PR DESCRIPTION
This fixes an issue with the opencode subagent where the permissions were explicitly overridden to be more restrictive. The reality is that it is best to just rely on the parent subscriptions so that the agent can run bash at the lease of the parent agent.