### PR TITLE
docs: migrate to agy

### DIFF
--- a/documentation/docs/30-mcp/20-local-setup.md
+++ b/documentation/docs/30-mcp/20-local-setup.md
@@ -68,7 +68,7 @@ Alternatively, create or edit `~/.copilot/mcp-config.json` and add the following
 
 ## Antigravity CLI
 
-To use the local MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json ` and add the following configuration:
+To use the local MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json` and add the following configuration:
 
 ```json
 {

--- a/documentation/docs/30-mcp/20-local-setup.md
+++ b/documentation/docs/30-mcp/20-local-setup.md
@@ -68,7 +68,7 @@ Alternatively, create or edit `~/.copilot/mcp-config.json` and add the following
 
 ## Antigravity CLI
 
-To include the local MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json ` and add the following configuration:
+To use the local MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json ` and add the following configuration:
 
 ```json
 {

--- a/documentation/docs/30-mcp/20-local-setup.md
+++ b/documentation/docs/30-mcp/20-local-setup.md
@@ -66,15 +66,20 @@ Alternatively, create or edit `~/.copilot/mcp-config.json` and add the following
 }
 ```
 
-## Gemini CLI
+## Antigravity CLI
 
-To include the local MCP version in Gemini CLI, simply run the following command:
+To include the local MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json ` and add the following configuration:
 
-```bash
-gemini mcp add -t stdio -s [scope] svelte npx -y @sveltejs/mcp
+```json
+{
+	"mcpServers": {
+		"svelte": {
+			"command": "npx",
+			"args": ["-y", "@sveltejs/mcp"]
+		}
+	}
+}
 ```
-
-The `[scope]` must be `user`, `project` or `local`.
 
 ## OpenCode
 

--- a/documentation/docs/30-mcp/30-remote-setup.md
+++ b/documentation/docs/30-mcp/30-remote-setup.md
@@ -56,15 +56,19 @@ Alternatively, create or edit `~/.copilot/mcp-config.json` and add the following
 }
 ```
 
-## Gemini CLI
+## Antigravity CLI
 
-To use the remote MCP server with Gemini CLI, simply run the following command:
+To include the remote MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json` and add the following configuration:
 
-```bash
-gemini mcp add -t http -s [scope] svelte https://mcp.svelte.dev/mcp
+```json
+{
+	"mcpServers": {
+		"svelte": {
+			"url": "https://mcp.svelte.dev/mcp"
+		}
+	}
+}
 ```
-
-The `[scope]` must be `user` or `project`.
 
 ## OpenCode
 

--- a/documentation/docs/30-mcp/30-remote-setup.md
+++ b/documentation/docs/30-mcp/30-remote-setup.md
@@ -58,7 +58,7 @@ Alternatively, create or edit `~/.copilot/mcp-config.json` and add the following
 
 ## Antigravity CLI
 
-To include the remote MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json` and add the following configuration:
+To use the remote MCP version in Antigravity CLI, create or edit `~/.gemini/config/mcp_config.json` and add the following configuration:
 
 ```json
 {


### PR DESCRIPTION
gemini-cli is no more supported, hence i have migrated the mcp docs to antigravity 