### PR TITLE
docs: codex plugin

### DIFF
--- a/documentation/docs/60-plugins/50-codex-plugin.md
+++ b/documentation/docs/60-plugins/50-codex-plugin.md
@@ -1,0 +1,28 @@
+---
+title: Codex CLI
+---
+
+The open source [repository](https://github.com/sveltejs/ai-tools) containing the code for the MCP server is also a Codex CLI [plugin marketplace](https://developers.openai.com/codex/plugins).
+
+The marketplace allows you to install the `svelte` plugin which will give you the remote MCP server, [skills](skills) to instruct the LLM on how to properly write Svelte 5 code, and a specialized agent for editing Svelte files.
+
+If possible, we recommend that you instruct the LLM to execute MCP calls with the agent (you can explicitly mention an agent in your message to delegate work to it) when creating or editing `.svelte` files or `.svelte.ts`/`.svelte.js` modules — this will help save context by handling Svelte-specific tasks more efficiently.
+
+## Installation
+
+Add the repository as a marketplace from the Codex CLI:
+
+```bash
+codex plugin marketplace add sveltejs/ai-tools
+```
+
+Then, open the plugin directory from an interactive Codex CLI session:
+
+```bash
+codex
+/plugins
+```
+
+Choose the Svelte marketplace, select the `svelte` plugin, and install it.
+
+Codex can read the repository's legacy-compatible `.claude-plugin/marketplace.json` marketplace file, so the same marketplace source works for both Claude Code and Codex CLI.


### PR DESCRIPTION
This adds the docs for the codex cli plugin (which we support with the claude plugin since codex reads that as a compatibility layer)