### PR TITLE
chore: use quotemarks instead of bold text

### DIFF
--- a/documentation/docs/60-plugins/20-opencode-plugin.md
+++ b/documentation/docs/60-plugins/20-opencode-plugin.md
@@ -34,7 +34,7 @@ The package also includes a TUI plugin for configuring these features interactiv
 }
 ```
 
-Restart OpenCode, then run `/svelte-plugin` or select **Configure Svelte plugin** from the command palette. Choose whether to edit the project or global configuration, then use the checkboxes and radio options to configure the plugin. Changes are saved automatically, and **Revert changes** restores the values from when the dialog was opened.
+Restart OpenCode, then run `/svelte-plugin` or select 'Configure Svelte plugin' from the command palette. Choose whether to edit the project or global configuration, then use the checkboxes and radio options to configure the plugin. Changes are saved automatically, and 'Revert changes' restores the values from when the dialog was opened.
 
 ## Configuration
 

--- a/documentation/docs/60-plugins/40-copilot-plugin.md
+++ b/documentation/docs/60-plugins/40-copilot-plugin.md
@@ -10,7 +10,7 @@ If possible, we recommend that you instruct the LLM to execute MCP calls with th
 
 ## Installation
 
-In VS Code, run the **Install plugin from source** command and use the repository URL:
+In VS Code, run the 'Install plugin from source' command and use the repository URL:
 
 ```text
 https://github.com/sveltejs/ai-tools


### PR DESCRIPTION
small nit — we don't use bold text in the docs, and in fact don't even load any weights greater than 400:

<img width="780" height="151" alt="image" src="https://github.com/user-attachments/assets/0e5e9877-901a-4030-89d6-b8ff12fdc8a4" />

Using quotes is therefore the easiest way to demarcate the option. (Ideally it would automatically turn into smart quotes but that broke a while back and I haven't got round to fixing yet)

Will self-merge to unblock https://github.com/sveltejs/svelte.dev/pull/2100