### PR TITLE
chore: show warning for old versions

### DIFF
--- a/.changeset/fancy-paws-say.md
+++ b/.changeset/fancy-paws-say.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/opencode': patch
+---
+
+chore: show warning for old versions

--- a/.changeset/lucky-cars-invite.md
+++ b/.changeset/lucky-cars-invite.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/opencode': minor
+---
+
+feat: add `autoupdate` option to reinstall the plugin when a new version is available

--- a/.changeset/lucky-cars-invite.md
+++ b/.changeset/lucky-cars-invite.md
@@ -1,5 +1,5 @@
 ---
-'@sveltejs/opencode': minor
+'@sveltejs/opencode': patch
 ---
 
 feat: add `autoupdate` option to reinstall the plugin when a new version is available

--- a/documentation/docs/60-plugins/20-opencode-plugin.md
+++ b/documentation/docs/60-plugins/20-opencode-plugin.md
@@ -38,7 +38,7 @@ Restart OpenCode, then run `/svelte-plugin` or select 'Configure Svelte plugin' 
 
 ## Configuration
 
-By default, everything is enabled. The TUI plugin writes the same configuration files that you can create or edit manually:
+By default, the MCP server, subagent, skills, instructions, and automatic updates are enabled. The TUI plugin writes the same configuration files that you can create or edit manually:
 
 - locally, in `.opencode/svelte.json`
 - globally, in `~/.config/opencode/svelte.json` (or, if you have specified the environment variable, in `$OPENCODE_CONFIG_DIR/svelte.json`)
@@ -68,6 +68,13 @@ By default, everything is enabled. The TUI plugin writes the same configuration 
 	},
 	"instructions": {
 		"enabled": true
-	}
+	},
+	"autoupdate": true
 }
 ```
+
+### Automatic updates
+
+The plugin checks npm for newer versions and warns you when one is available. OpenCode caches plugins, so it continues using the cached version until that cache is removed.
+
+Automatic updates are enabled by default. After detecting a newer version, the plugin removes itself from the cache when OpenCode shuts down. OpenCode installs the latest version the next time it starts. Automatic updates only apply when the plugin is unpinned or explicitly uses the `latest` tag. Exact versions, ranges, and other dist-tags are left untouched because reinstalling them may resolve to the same version again. Set `"autoupdate": false` to only receive the warning.

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -72,9 +72,16 @@ Create `svelte.json` to customize how the plugin configures MCP, the Svelte suba
 	},
 	"skills": {
 		"enabled": ["svelte-code-writer", "svelte-core-bestpractices"]
-	}
+	},
+	"autoupdate": false
 }
 ```
+
+### Auto update
+
+The plugin checks npm for newer versions and warns you when one is available. OpenCode caches plugins, so a new version is only picked up once that cache is wiped.
+
+Setting `"autoupdate": true` automates it: when a newer version is detected, the plugin removes itself from the OpenCode cache as OpenCode shuts down, so the latest version is installed on the next start. It is a no-op when the plugin is pinned to an exact version (for example `"@sveltejs/opencode@0.1.11"`), since reinstalling would only fetch the very same version again.
 
 ### Defaults
 
@@ -86,6 +93,7 @@ If omitted, the plugin uses these defaults:
 - `subagent.agents`: `{}`
 - `instructions.enabled`: `true`
 - `skills.enabled`: `true`
+- `autoupdate`: `false`
 
 ### Configuration Options
 
@@ -100,6 +108,7 @@ If omitted, the plugin uses these defaults:
 | `subagent.agents.svelte-file-editor.maxSteps`    | `number`              | unlimited  | Limit the number of steps the subagent can execute.                                            |
 | `instructions.enabled`                           | `boolean`             | `true`     | Enable or disable automatic instruction-file injection.                                        |
 | `skills.enabled`                                 | `boolean \| string[]` | `true`     | Enable all skills (`true`), disable all skills (`false`), or enable only specific skill names. |
+| `autoupdate`                                     | `boolean`             | `false`    | Remove the plugin from the OpenCode cache on exit when a newer version is available.           |
 
 ### Supported Skill Names
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -81,7 +81,7 @@ Create `svelte.json` to customize how the plugin configures MCP, the Svelte suba
 
 The plugin checks npm for newer versions and warns you when one is available. OpenCode caches plugins, so a new version is only picked up once that cache is wiped.
 
-Setting `"autoupdate": true` automates it: when a newer version is detected, the plugin removes itself from the OpenCode cache as OpenCode shuts down, so the latest version is installed on the next start. It is a no-op when the plugin is pinned to an exact version (for example `"@sveltejs/opencode@0.1.11"`), since reinstalling would only fetch the very same version again.
+Setting `"autoupdate": true` automates it: when a newer version is detected, the plugin removes itself from the OpenCode cache as OpenCode shuts down, so the latest version is installed on the next start. It only applies when the plugin is unpinned or explicitly uses the `latest` tag. Exact versions, ranges, and other dist-tags are left untouched because reinstalling them may resolve to the same version again.
 
 ### Defaults
 
@@ -108,7 +108,7 @@ If omitted, the plugin uses these defaults:
 | `subagent.agents.svelte-file-editor.maxSteps`    | `number`              | unlimited  | Limit the number of steps the subagent can execute.                                            |
 | `instructions.enabled`                           | `boolean`             | `true`     | Enable or disable automatic instruction-file injection.                                        |
 | `skills.enabled`                                 | `boolean \| string[]` | `true`     | Enable all skills (`true`), disable all skills (`false`), or enable only specific skill names. |
-| `autoupdate`                                     | `boolean`             | `false`    | Remove the plugin from the OpenCode cache on exit when a newer version is available.           |
+| `autoupdate`                                     | `boolean`             | `false`    | Remove an unpinned/latest plugin from the cache on exit when a newer version is available.     |
 
 ### Supported Skill Names
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -73,7 +73,7 @@ Create `svelte.json` to customize how the plugin configures MCP, the Svelte suba
 	"skills": {
 		"enabled": ["svelte-code-writer", "svelte-core-bestpractices"]
 	},
-	"autoupdate": false
+	"autoupdate": true
 }
 ```
 
@@ -81,7 +81,7 @@ Create `svelte.json` to customize how the plugin configures MCP, the Svelte suba
 
 The plugin checks npm for newer versions and warns you when one is available. OpenCode caches plugins, so a new version is only picked up once that cache is wiped.
 
-Setting `"autoupdate": true` automates it: when a newer version is detected, the plugin removes itself from the OpenCode cache as OpenCode shuts down, so the latest version is installed on the next start. It only applies when the plugin is unpinned or explicitly uses the `latest` tag. Exact versions, ranges, and other dist-tags are left untouched because reinstalling them may resolve to the same version again.
+Automatic updates are enabled by default. When a newer version is detected, the plugin removes itself from the OpenCode cache as OpenCode shuts down, so the latest version is installed on the next start. This only applies when the plugin is unpinned or explicitly uses the `latest` tag. Exact versions, ranges, and other dist-tags are left untouched because reinstalling them may resolve to the same version again. Set `"autoupdate": false` to only receive the warning.
 
 ### Defaults
 
@@ -93,7 +93,7 @@ If omitted, the plugin uses these defaults:
 - `subagent.agents`: `{}`
 - `instructions.enabled`: `true`
 - `skills.enabled`: `true`
-- `autoupdate`: `false`
+- `autoupdate`: `true`
 
 ### Configuration Options
 
@@ -108,7 +108,7 @@ If omitted, the plugin uses these defaults:
 | `subagent.agents.svelte-file-editor.maxSteps`    | `number`              | unlimited  | Limit the number of steps the subagent can execute.                                            |
 | `instructions.enabled`                           | `boolean`             | `true`     | Enable or disable automatic instruction-file injection.                                        |
 | `skills.enabled`                                 | `boolean \| string[]` | `true`     | Enable all skills (`true`), disable all skills (`false`), or enable only specific skill names. |
-| `autoupdate`                                     | `boolean`             | `false`    | Remove an unpinned/latest plugin from the cache on exit when a newer version is available.     |
+| `autoupdate`                                     | `boolean`             | `true`     | Remove an unpinned/latest plugin from the cache on exit when a newer version is available.     |
 
 ### Supported Skill Names
 

--- a/packages/opencode/config.js
+++ b/packages/opencode/config.js
@@ -42,6 +42,7 @@ const default_config = {
 	skills: {
 		enabled: /** @type {boolean | string[]} */ (true),
 	},
+	autoupdate: false,
 };
 
 export const config_schema = v.object({
@@ -88,6 +89,12 @@ export const config_schema = v.object({
 		),
 		v.description(
 			'Configuration for the skills. You can choose if it they should be enabled or not, or specify an array of skill names to enable only specific skills.',
+		),
+	),
+	autoupdate: v.pipe(
+		v.optional(v.boolean()),
+		v.description(
+			'When a new version of the plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning.',
 		),
 	),
 });
@@ -184,6 +191,7 @@ function merge_with_defaults(user_config) {
 			...default_config.skills,
 			...user_config.skills,
 		},
+		autoupdate: user_config.autoupdate ?? default_config.autoupdate,
 	};
 }
 
@@ -221,6 +229,7 @@ export function get_mcp_config(ctx) {
 					},
 					instructions: { ...merged.instructions, ...parsed.output.instructions },
 					skills: { ...merged.skills, ...parsed.output.skills },
+					autoupdate: parsed.output.autoupdate ?? merged.autoupdate,
 				};
 			} else {
 				setTimeout(() => {

--- a/packages/opencode/config.js
+++ b/packages/opencode/config.js
@@ -42,7 +42,7 @@ const default_config = {
 	skills: {
 		enabled: /** @type {boolean | string[]} */ (true),
 	},
-	autoupdate: false,
+	autoupdate: true,
 };
 
 export const config_schema = v.object({
@@ -94,7 +94,7 @@ export const config_schema = v.object({
 	autoupdate: v.pipe(
 		v.optional(v.boolean()),
 		v.description(
-			'When a new version of an unpinned or latest-tagged plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning.',
+			'When a new version of an unpinned or latest-tagged plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Enabled by default; set it to false to only get a warning.',
 		),
 	),
 });

--- a/packages/opencode/config.js
+++ b/packages/opencode/config.js
@@ -94,7 +94,7 @@ export const config_schema = v.object({
 	autoupdate: v.pipe(
 		v.optional(v.boolean()),
 		v.description(
-			'When a new version of the plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning.',
+			'When a new version of an unpinned or latest-tagged plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning.',
 		),
 	),
 });

--- a/packages/opencode/index.js
+++ b/packages/opencode/index.js
@@ -3,6 +3,9 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { agents } from './agents.js';
 import { get_mcp_config } from './config.js';
+import package_json from './package.json' with { type: 'json' };
+import { exec } from 'node:child_process';
+import { compare } from 'verkit';
 
 /** @typedef {import('@opencode-ai/plugin').Plugin} Plugin */
 
@@ -13,6 +16,21 @@ const current_dir = dirname(fileURLToPath(import.meta.url));
  * @returns {ReturnType<Plugin>}
  */
 export async function svelte_plugin(ctx) {
+	exec(`npm view ${package_json.name} version`, (_, version) => {
+		const result = compare(version, package_json.version);
+		if (result === 1) {
+			setTimeout(() => {
+				ctx.client.tui.showToast({
+					body: {
+						title: 'Svelte: new plugin version available',
+						message: `${package_json.name}@${version.trim()} is available (you are using ${package_json.version}).\n\nWipe the cache or update you opencode config to update.`,
+						variant: 'warning',
+						duration: 7000,
+					},
+				});
+			}, 7000);
+		}
+	});
 	return {
 		async config(input) {
 			input.agent ??= {};

--- a/packages/opencode/index.js
+++ b/packages/opencode/index.js
@@ -3,9 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { agents } from './agents.js';
 import { get_mcp_config } from './config.js';
-import package_json from './package.json' with { type: 'json' };
-import { exec } from 'node:child_process';
-import { compare } from 'verkit';
+import { setup_updates } from './update.js';
 
 /** @typedef {import('@opencode-ai/plugin').Plugin} Plugin */
 
@@ -16,22 +14,11 @@ const current_dir = dirname(fileURLToPath(import.meta.url));
  * @returns {ReturnType<Plugin>}
  */
 export async function svelte_plugin(ctx) {
-	exec(`npm view ${package_json.name} version`, (_, version) => {
-		const result = compare(version, package_json.version);
-		if (result === 1) {
-			setTimeout(() => {
-				ctx.client.tui.showToast({
-					body: {
-						title: 'Svelte: new plugin version available',
-						message: `${package_json.name}@${version.trim()} is available (you are using ${package_json.version}).\n\nWipe the cache or update you opencode config to update.`,
-						variant: 'warning',
-						duration: 7000,
-					},
-				});
-			}, 7000);
-		}
-	});
+	const mcp_config = get_mcp_config(ctx);
+	const dispose = setup_updates(ctx, mcp_config.autoupdate === true);
+
 	return {
+		dispose,
 		async config(input) {
 			input.agent ??= {};
 			input.mcp ??= {};
@@ -54,7 +41,6 @@ export async function svelte_plugin(ctx) {
 					break;
 				}
 			}
-			const mcp_config = get_mcp_config(ctx);
 
 			if (mcp_config.instructions?.enabled !== false) {
 				const instructions_dir = join(current_dir, 'instructions');

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -38,15 +38,16 @@
 		"access": "public"
 	},
 	"dependencies": {
-		"valibot": "catalog:tooling",
 		"@opentui/core": "catalog:opencode",
 		"@opentui/keymap": "catalog:opencode",
 		"@opentui/solid": "catalog:opencode",
-		"solid-js": "catalog:opencode"
+		"solid-js": "catalog:opencode",
+		"valibot": "catalog:tooling",
+		"verkit": "catalog:tooling"
 	},
 	"devDependencies": {
 		"@opencode-ai/plugin": "catalog:opencode",
-		"@valibot/to-json-schema": "catalog:tooling",
-		"@types/node": "catalog:tooling"
+		"@types/node": "catalog:tooling",
+		"@valibot/to-json-schema": "catalog:tooling"
 	}
 }

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -14,6 +14,7 @@
 	"files": [
 		"index.js",
 		"config.js",
+		"update.js",
 		"tui.jsx",
 		"agents.js",
 		"instructions",

--- a/packages/opencode/schema.json
+++ b/packages/opencode/schema.json
@@ -107,7 +107,7 @@
 		},
 		"autoupdate": {
 			"type": "boolean",
-			"description": "When a new version of the plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning."
+			"description": "When a new version of an unpinned or latest-tagged plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning."
 		}
 	},
 	"required": [],

--- a/packages/opencode/schema.json
+++ b/packages/opencode/schema.json
@@ -107,7 +107,7 @@
 		},
 		"autoupdate": {
 			"type": "boolean",
-			"description": "When a new version of an unpinned or latest-tagged plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning."
+			"description": "When a new version of an unpinned or latest-tagged plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Enabled by default; set it to false to only get a warning."
 		}
 	},
 	"required": [],

--- a/packages/opencode/schema.json
+++ b/packages/opencode/schema.json
@@ -104,6 +104,10 @@
 			},
 			"required": [],
 			"description": "Configuration for the skills. You can choose if it they should be enabled or not, or specify an array of skill names to enable only specific skills."
+		},
+		"autoupdate": {
+			"type": "boolean",
+			"description": "When a new version of the plugin is available, remove it from the opencode cache on exit so that the latest version is installed the next time opencode starts. Disabled by default: without it you only get a warning."
 		}
 	},
 	"required": [],

--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -5,6 +5,6 @@
 		"jsxImportSource": "@opentui/solid",
 		"types": ["@types/node"]
 	},
-	"include": ["index.js", "config.js", "agents.js", "tui.jsx", "scripts/*"],
+	"include": ["index.js", "config.js", "update.js", "agents.js", "tui.jsx", "scripts/*"],
 	"exclude": ["node_modules"]
 }

--- a/packages/opencode/tui.jsx
+++ b/packages/opencode/tui.jsx
@@ -251,7 +251,7 @@ const tui = async (api) => {
 							category: 'Skills',
 						})),
 						{
-							title: `${config.autoupdate === true ? '[x]' : '[ ]'} Auto update`,
+							title: `${config.autoupdate !== false ? '[x]' : '[ ]'} Auto update`,
 							value: 'autoupdate',
 							category: 'Updates',
 							description: 'Reinstall the plugin on the next start when a new version is out',
@@ -290,7 +290,7 @@ const tui = async (api) => {
 						if (option.value === 'skills-all') {
 							config.skills = { enabled: all_skills_selected ? [] : [...skill_names] };
 						}
-						if (option.value === 'autoupdate') config.autoupdate = config.autoupdate !== true;
+						if (option.value === 'autoupdate') config.autoupdate = config.autoupdate === false;
 						if (option.value.startsWith('skill:')) {
 							const name = option.value.slice('skill:'.length);
 							if (selected_skills.has(name)) {

--- a/packages/opencode/tui.jsx
+++ b/packages/opencode/tui.jsx
@@ -251,6 +251,12 @@ const tui = async (api) => {
 							category: 'Skills',
 						})),
 						{
+							title: `${config.autoupdate === true ? '[x]' : '[ ]'} Auto update`,
+							value: 'autoupdate',
+							category: 'Updates',
+							description: 'Reinstall the plugin on the next start when a new version is out',
+						},
+						{
 							title: 'Revert changes',
 							value: 'revert',
 							category: 'Actions',
@@ -284,6 +290,7 @@ const tui = async (api) => {
 						if (option.value === 'skills-all') {
 							config.skills = { enabled: all_skills_selected ? [] : [...skill_names] };
 						}
+						if (option.value === 'autoupdate') config.autoupdate = config.autoupdate !== true;
 						if (option.value.startsWith('skill:')) {
 							const name = option.value.slice('skill:'.length);
 							if (selected_skills.has(name)) {

--- a/packages/opencode/update.js
+++ b/packages/opencode/update.js
@@ -1,0 +1,95 @@
+import { exec } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import { basename, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { compare } from 'verkit';
+import package_json from './package.json' with { type: 'json' };
+
+/** @typedef {import('@opencode-ai/plugin').PluginInput} PluginInput */
+
+const current_dir = dirname(fileURLToPath(import.meta.url));
+const name_segments = package_json.name.split('/');
+
+/**
+ * @param {string} dir
+ * @param {number} levels
+ */
+function up(dir, levels) {
+	for (let i = 0; i < levels; i++) dir = dirname(dir);
+	return dir;
+}
+
+/**
+ * opencode installs every plugin in `<cache>/packages/<spec>/node_modules/<name>`, so removing
+ * `<spec>` is enough to make it reinstall the plugin from scratch on the next start.
+ *
+ * We return `null` whenever we don't recognize that layout (for example when the plugin is linked
+ * locally during development) so that we never delete a folder we don't own.
+ */
+function get_install_dir() {
+	// from `<cache>/packages/<spec>/node_modules/<name>` up to `<cache>/packages/<spec>`
+	const install_dir = up(current_dir, name_segments.length + 1);
+	// ...and from there up to `<cache>/packages`
+	if (basename(up(install_dir, name_segments.length)) !== 'packages') return null;
+	// an exact version means the user pinned the plugin: wiping the cache would just reinstall the
+	// very same version over and over again
+	const version_spec = basename(install_dir).split('@').at(-1) ?? '';
+	if (/^\d+\.\d+\.\d+/.test(version_spec)) return null;
+	return install_dir;
+}
+
+/**
+ * Checks npm for a newer version of the plugin and warns the user about it. If `autoupdate` is
+ * enabled we also delete the cached plugin once opencode shuts down, so the next start picks up the
+ * new version.
+ *
+ * @param {PluginInput} ctx
+ * @param {boolean} autoupdate
+ * @returns {() => Promise<void>} the `dispose` hook
+ */
+export function setup_updates(ctx, autoupdate) {
+	/** @type {string | null} */
+	let stale_dir = null;
+	let wiped = false;
+
+	function wipe() {
+		if (wiped || !stale_dir) return;
+		wiped = true;
+		try {
+			rmSync(stale_dir, { recursive: true, force: true });
+		} catch {
+			// if we can't delete it there's nothing useful we can do at this point, the user will
+			// just get the warning again on the next start
+		}
+	}
+
+	exec(`npm view ${package_json.name} version`, (_, version) => {
+		const latest = version?.trim();
+		if (!latest || compare(latest, package_json.version) !== 1) return;
+
+		stale_dir = autoupdate ? get_install_dir() : null;
+		// `dispose` covers a graceful shutdown, `exit` is the safety net for everything else. We only
+		// register it once we know we have something to delete to avoid piling up listeners.
+		if (stale_dir) process.once('exit', wipe);
+
+		setTimeout(() => {
+			ctx.client.tui.showToast({
+				body: {
+					title: 'Svelte: new plugin version available',
+					message: `${package_json.name}@${latest} is available (you are using ${package_json.version}).\n\n${
+						stale_dir
+							? 'It will be installed automatically the next time you start opencode.'
+							: 'Wipe the cache or update you opencode config to update.'
+					}`,
+					variant: 'warning',
+					duration: 7000,
+				},
+			});
+		}, 7000);
+	});
+
+	return async () => {
+		process.off('exit', wipe);
+		wipe();
+	};
+}

--- a/packages/opencode/update.js
+++ b/packages/opencode/update.js
@@ -26,15 +26,17 @@ function up(dir, levels) {
  * We return `null` whenever we don't recognize that layout (for example when the plugin is linked
  * locally during development) so that we never delete a folder we don't own.
  */
-function get_install_dir() {
+export function get_install_dir(dir = current_dir) {
 	// from `<cache>/packages/<spec>/node_modules/<name>` up to `<cache>/packages/<spec>`
-	const install_dir = up(current_dir, name_segments.length + 1);
+	const install_dir = up(dir, name_segments.length + 1);
 	// ...and from there up to `<cache>/packages`
 	if (basename(up(install_dir, name_segments.length)) !== 'packages') return null;
-	// an exact version means the user pinned the plugin: wiping the cache would just reinstall the
-	// very same version over and over again
-	const version_spec = basename(install_dir).split('@').at(-1) ?? '';
-	if (/^\d+\.\d+\.\d+/.test(version_spec)) return null;
+	// Only unconstrained installs can pick up npm's latest version. Ranges and alternate tags may
+	// resolve to the same installed version after every wipe.
+	const package_name = name_segments.at(-1);
+	if (!package_name || ![package_name, `${package_name}@latest`].includes(basename(install_dir))) {
+		return null;
+	}
 	return install_dir;
 }
 

--- a/packages/opencode/update.js
+++ b/packages/opencode/update.js
@@ -78,8 +78,8 @@ export function setup_updates(ctx, autoupdate) {
 					title: 'Svelte: new plugin version available',
 					message: `${package_json.name}@${latest} is available (you are using ${package_json.version}).\n\n${
 						stale_dir
-							? 'It will be installed automatically the next time you start opencode.'
-							: 'Wipe the cache or update you opencode config to update.'
+							? 'It will be installed automatically the next time you start OpenCode.'
+							: 'Wipe the cache or update your OpenCode config to update.'
 					}`,
 					variant: 'warning',
 					duration: 7000,

--- a/packages/opencode/update.test.js
+++ b/packages/opencode/update.test.js
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { get_install_dir } from './update.js';
+
+const cache_packages = join('/cache', 'packages');
+
+/**
+ * @param {string} spec
+ */
+function plugin_dir(spec) {
+	return join(cache_packages, '@sveltejs', spec, 'node_modules', '@sveltejs', 'opencode');
+}
+
+describe('get_install_dir', () => {
+	test.each([
+		['an unpinned install', 'opencode'],
+		['the latest tag', 'opencode@latest'],
+	])('returns the cache directory for %s', (_, spec) => {
+		expect(get_install_dir(plugin_dir(spec))).toBe(join(cache_packages, '@sveltejs', spec));
+	});
+
+	test.each([
+		['an exact version', 'opencode@0.1.11'],
+		['an exact version with a v prefix', 'opencode@v0.1.11'],
+		['a range', 'opencode@^0.1.0'],
+		['an alternate dist-tag', 'opencode@beta'],
+	])('ignores %s', (_, spec) => {
+		expect(get_install_dir(plugin_dir(spec))).toBeNull();
+	});
+
+	test('ignores a matching layout outside the OpenCode package cache', () => {
+		const dir = join('/workspace', 'node_modules', '@sveltejs', 'opencode');
+		expect(get_install_dir(dir)).toBeNull();
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ catalogs:
       version: 1.5.0
     eslint-plugin-svelte:
       specifier: ^3.19.0
-      version: 3.14.0
+      version: 3.19.0
     globals:
       specifier: ^17.0.0
       version: 17.2.0
@@ -149,6 +149,9 @@ catalogs:
     valibot:
       specifier: ^1.2.0
       version: 1.2.0
+    verkit:
+      specifier: ^0.1.2
+      version: 0.1.2
     vite:
       specifier: ^7.0.4
       version: 7.3.1
@@ -412,6 +415,9 @@ importers:
       valibot:
         specifier: catalog:tooling
         version: 1.2.0(typescript@5.9.3)
+      verkit:
+        specifier: catalog:tooling
+        version: 0.1.2
     devDependencies:
       '@opencode-ai/plugin':
         specifier: catalog:opencode
@@ -4517,6 +4523,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  verkit@0.1.2:
+    resolution: {integrity: sha512-WqkT8n3hqizuCu71W3bUzf5fjBmkbXcudsehe/NbxA8PgqoKnSOY5K0Ba2ckg1qaRaSpSz7as/n9K1R9JXjQKg==}
+    engines: {node: '>=18.12.0'}
 
   vite-plugin-devtools-json@1.0.0:
     resolution: {integrity: sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw==}
@@ -8914,6 +8924,8 @@ snapshots:
       typescript: 5.9.3
 
   vary@1.1.2: {}
+
+  verkit@0.1.2: {}
 
   vite-plugin-devtools-json@1.0.0(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ catalogs:
       version: 1.5.0
     eslint-plugin-svelte:
       specifier: ^3.19.0
-      version: 3.14.0
+      version: 3.19.0
     globals:
       specifier: ^17.0.0
       version: 17.2.0
@@ -149,6 +149,9 @@ catalogs:
     valibot:
       specifier: ^1.2.0
       version: 1.2.0
+    verkit:
+      specifier: ^0.1.2
+      version: 0.1.2
     vite:
       specifier: ^7.0.4
       version: 7.3.1
@@ -412,6 +415,9 @@ importers:
       valibot:
         specifier: catalog:tooling
         version: 1.2.0(typescript@5.9.3)
+      verkit:
+        specifier: catalog:tooling
+        version: 0.1.2
     devDependencies:
       '@opencode-ai/plugin':
         specifier: catalog:opencode
@@ -4516,6 +4522,10 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  verkit@0.1.2:
+    resolution: {integrity: sha512-WqkT8n3hqizuCu71W3bUzf5fjBmkbXcudsehe/NbxA8PgqoKnSOY5K0Ba2ckg1qaRaSpSz7as/n9K1R9JXjQKg==}
+    engines: {node: '>=18.12.0'}
 
   vite-plugin-devtools-json@1.0.0:
     resolution: {integrity: sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw==}
@@ -8913,6 +8923,8 @@ snapshots:
       typescript: 5.9.3
 
   vary@1.1.2: {}
+
+  verkit@0.1.2: {}
 
   vite-plugin-devtools-json@1.0.0(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ catalogs:
       version: 1.5.0
     eslint-plugin-svelte:
       specifier: ^3.19.0
-      version: 3.19.0
+      version: 3.14.0
     globals:
       specifier: ^17.0.0
       version: 17.2.0
@@ -149,9 +149,6 @@ catalogs:
     valibot:
       specifier: ^1.2.0
       version: 1.2.0
-    verkit:
-      specifier: ^0.1.2
-      version: 0.1.2
     vite:
       specifier: ^7.0.4
       version: 7.3.1
@@ -415,9 +412,6 @@ importers:
       valibot:
         specifier: catalog:tooling
         version: 1.2.0(typescript@5.9.3)
-      verkit:
-        specifier: catalog:tooling
-        version: 0.1.2
     devDependencies:
       '@opencode-ai/plugin':
         specifier: catalog:opencode
@@ -3147,7 +3141,6 @@ packages:
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -4523,10 +4516,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  verkit@0.1.2:
-    resolution: {integrity: sha512-WqkT8n3hqizuCu71W3bUzf5fjBmkbXcudsehe/NbxA8PgqoKnSOY5K0Ba2ckg1qaRaSpSz7as/n9K1R9JXjQKg==}
-    engines: {node: '>=18.12.0'}
 
   vite-plugin-devtools-json@1.0.0:
     resolution: {integrity: sha512-MobvwqX76Vqt/O4AbnNMNWoXWGrKUqZbphCUle/J2KXH82yKQiunOeKnz/nqEPosPsoWWPP9FtNuPBSYpiiwkw==}
@@ -8924,8 +8913,6 @@ snapshots:
       typescript: 5.9.3
 
   vary@1.1.2: {}
-
-  verkit@0.1.2: {}
 
   vite-plugin-devtools-json@1.0.0(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,12 +8,6 @@ catalogs:
     '@anthropic-ai/sdk': ^0.71.0
     '@mcp-ui/server': ^6.0.0
     '@modelcontextprotocol/inspector': ^0.19.0
-  opencode:
-    '@opencode-ai/plugin': 1.17.9
-    '@opentui/core': ^0.4.3
-    '@opentui/keymap': ^0.4.3
-    '@opentui/solid': ^0.4.3
-    solid-js: 1.9.12
   lint:
     '@eslint/compat': ^2.0.0
     '@eslint/js': ^9.36.0
@@ -29,6 +23,12 @@ catalogs:
     prettier-plugin-svelte: ^3.3.3
     svelte-eslint-parser: ^1.7.1
     typescript-eslint: ^8.44.0
+  opencode:
+    '@opencode-ai/plugin': 1.17.9
+    '@opentui/core': ^0.4.3
+    '@opentui/keymap': ^0.4.3
+    '@opentui/solid': ^0.4.3
+    solid-js: 1.9.12
   svelte:
     '@sveltejs/adapter-vercel': ^6.0.0
     '@sveltejs/kit': ^2.42.2
@@ -56,6 +56,7 @@ catalogs:
     tsdown: ^0.20.0
     typescript: ^5.0.0
     valibot: ^1.2.0
+    verkit: ^0.1.2
     vite: ^7.0.4
     vite-plugin-devtools-json: ^1.0.0
     vitest: ^4.0.0


### PR DESCRIPTION
There's an issue I've been dealing for a bit with the opencode plugin and I finally got around to understand.

I found a lot of times opencode uses old versions of the plugin. What I found out today is that opencode caches the plugin, for the whole computer, basically indefinitely, by name.

This means that if you created a new project 2 months ago with the opencode plugin setup from the svelte cli and ran opencode every new project would use the version of the plugin of 2 months ago.

This is especially annoying because you don't have any clue about this fact.

One solution could be to suggest to use fixed versions in the config (and also set those up within `sv`). But that still means that the version is pinned, it just means that new projects might use the new version. We can definitely do this but I also thought of adding this small script upon starting up that checks for the current latest version on npm and compares it with the version in the package.json and warns the user about it.

A couple of points:

- I would love to auto update the plugin...we could technically do that by using the versionless plugin AND by wiping the cache (deleting the folder) if the npm version is newer...not sure of the consequences tho because the file being deleted are technically the ones that needs to be deleted.
- I'm not sure about the phrasing...ideally we would provide a way to wipe the cache in the warning but the command is annoying and scary looking.
- this also doesn't really do anything for the desktop app but I don't think plugins can send notifications there unfortunately 😅