### PR TITLE
fix: new protocol version

### DIFF
--- a/.changeset/loud-balloons-relax.md
+++ b/.changeset/loud-balloons-relax.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/mcp': patch
+---
+
+fix: new protocol version

--- a/apps/mcp-remote/src/hooks.server.ts
+++ b/apps/mcp-remote/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import { dev } from '$app/environment';
-import { http_transport } from '$lib/mcp/index.js';
+import { http_transport, server } from '$lib/mcp/index.js';
 import { redirect } from '@sveltejs/kit';
 import { track } from '@vercel/analytics/server';
 
@@ -20,7 +20,13 @@ export async function handle({ event, resolve }) {
 		track: dev
 			? undefined
 			: async (session_id, event, extra) => {
-					await track(event, { session_id, ...(extra ? { extra } : {}) });
+					await track(event, {
+						...(session_id ? { session_id } : {}),
+						...(extra ? { extra } : {}),
+						...(server.ctx?.protocolVersion
+							? { protocol_version: server.ctx.protocolVersion }
+							: {}),
+					});
 				},
 	});
 	return mcp_response ?? resolve(event);

--- a/apps/mcp-remote/src/lib/mcp/index.ts
+++ b/apps/mcp-remote/src/lib/mcp/index.ts
@@ -10,3 +10,5 @@ export const http_transport = new HttpTransport(server, {
 	// after 5 minutes making the logs dirty.
 	disableSse: true,
 });
+
+export { server };

--- a/packages/mcp-server/src/mcp/handlers/prompts/svelte-task.ts
+++ b/packages/mcp-server/src/mcp/handlers/prompts/svelte-task.ts
@@ -71,8 +71,8 @@ export function setup_svelte_task(server: SvelteMcp) {
 			icons,
 		},
 		async ({ task }) => {
-			if (server.ctx.sessionId && server.ctx.custom?.track) {
-				await server.ctx.custom?.track?.(server.ctx.sessionId, 'svelte-task');
+			if (server.ctx.custom?.track) {
+				await server.ctx.custom.track(server.ctx.sessionId, 'svelte-task');
 			}
 			const available_docs = await format_sections_list();
 

--- a/packages/mcp-server/src/mcp/handlers/resources/doc-section.ts
+++ b/packages/mcp-server/src/mcp/handlers/resources/doc-section.ts
@@ -47,8 +47,8 @@ export async function list_sections(server: SvelteMcp) {
 			icons,
 		},
 		async (uri, { slug }) => {
-			if (server.ctx.sessionId && server.ctx.custom?.track) {
-				await server.ctx.custom?.track?.(
+			if (server.ctx.custom?.track) {
+				await server.ctx.custom.track(
 					server.ctx.sessionId,
 					'svelte-doc-section',
 					Array.isArray(slug) ? slug.join(',') : slug,

--- a/packages/mcp-server/src/mcp/handlers/tools/get-documentation.ts
+++ b/packages/mcp-server/src/mcp/handlers/tools/get-documentation.ts
@@ -159,16 +159,16 @@ export function get_documentation(server: SvelteMcp) {
 			icons,
 		},
 		async ({ section }) => {
-			if (server.ctx.sessionId && server.ctx.custom?.track) {
-				await server.ctx.custom?.track?.(server.ctx.sessionId, 'get-documentation');
+			if (server.ctx.custom?.track) {
+				await server.ctx.custom.track(server.ctx.sessionId, 'get-documentation');
 			}
 			try {
 				const content = await get_documentation_handler({ section });
 				return tool.text(content);
 			} catch (e) {
 				const error = e as Error;
-				if (server.ctx.sessionId && server.ctx.custom?.track) {
-					await server.ctx.custom?.track?.(
+				if (server.ctx.custom?.track) {
+					await server.ctx.custom.track(
 						server.ctx.sessionId,
 						'get-documentation-error',
 						error.message,

--- a/packages/mcp-server/src/mcp/handlers/tools/list-sections.ts
+++ b/packages/mcp-server/src/mcp/handlers/tools/list-sections.ts
@@ -25,16 +25,16 @@ export function list_sections(server: SvelteMcp) {
 			icons,
 		},
 		async () => {
-			if (server.ctx.sessionId && server.ctx.custom?.track) {
-				await server.ctx.custom?.track?.(server.ctx.sessionId, 'list-sections');
+			if (server.ctx.custom?.track) {
+				await server.ctx.custom.track(server.ctx.sessionId, 'list-sections');
 			}
 			try {
 				const content = await list_sections_handler();
 				return tool.text(content);
 			} catch (e) {
 				const error = e as Error;
-				if (server.ctx.sessionId && server.ctx.custom?.track) {
-					await server.ctx.custom?.track?.(
+				if (server.ctx.custom?.track) {
+					await server.ctx.custom.track(
 						server.ctx.sessionId,
 						'list-sections-error',
 						error.message,

--- a/packages/mcp-server/src/mcp/handlers/tools/list-sections.ts
+++ b/packages/mcp-server/src/mcp/handlers/tools/list-sections.ts
@@ -34,11 +34,7 @@ export function list_sections(server: SvelteMcp) {
 			} catch (e) {
 				const error = e as Error;
 				if (server.ctx.custom?.track) {
-					await server.ctx.custom.track(
-						server.ctx.sessionId,
-						'list-sections-error',
-						error.message,
-					);
+					await server.ctx.custom.track(server.ctx.sessionId, 'list-sections-error', error.message);
 				}
 				return tool.error(error.message);
 			}

--- a/packages/mcp-server/src/mcp/handlers/tools/playground-link.test.ts
+++ b/packages/mcp-server/src/mcp/handlers/tools/playground-link.test.ts
@@ -4,23 +4,27 @@ import { server } from '../../index.js';
 
 const transport = new InMemoryTransport(server);
 
-let session: ReturnType<typeof transport.session>;
+let client: ReturnType<typeof transport.session> | ReturnType<typeof transport.stateless>;
 
-describe('playground-link tool', () => {
+describe.each(['session', 'stateless'])('playground-link tool - %s', (kind) => {
 	beforeEach(async () => {
-		session = transport.session();
-		await session.initialize(
-			'2025-06-18',
-			{},
-			{
-				name: 'test-client',
-				version: '1.0.0',
-			},
-		);
+		if (kind === 'session') {
+			client = transport.session();
+			await client.initialize(
+				'2025-06-18',
+				{},
+				{
+					name: 'test-client',
+					version: '1.0.0',
+				},
+			);
+		} else {
+			client = transport.stateless();
+		}
 	});
 
 	it('should create a playground link if App.svelte is present', async () => {
-		const result = await session.callTool<{ url: string }>('playground-link', {
+		const result = await client.callTool<{ url: string }>('playground-link', {
 			name: 'My Playground',
 			tailwind: false,
 			files: {
@@ -35,7 +39,7 @@ describe('playground-link tool', () => {
 	});
 
 	it('should have a content with the stringified version of structured content and an ui resource', async () => {
-		const result = await session.callTool<{ url: string }>('playground-link', {
+		const result = await client.callTool<{ url: string }>('playground-link', {
 			name: 'My Playground',
 			tailwind: false,
 			files: {
@@ -68,7 +72,7 @@ describe('playground-link tool', () => {
 	});
 
 	it('should have tool _meta with resource URI for MCP Apps hosts', async () => {
-		const tools = await session.listTools();
+		const tools = await client.listTools();
 		const playground_tool = tools.tools.find((t) => t.name === 'playground-link');
 		expect(playground_tool).toBeDefined();
 		expect(playground_tool?._meta).toStrictEqual({
@@ -77,7 +81,7 @@ describe('playground-link tool', () => {
 	});
 
 	it('should expose a resource for MCP Apps hosts', async () => {
-		const resources = await session.listResources();
+		const resources = await client.listResources();
 		const playground_resource = resources.resources.find(
 			(r) => r.uri === 'ui://svelte/playground-link',
 		);
@@ -86,7 +90,7 @@ describe('playground-link tool', () => {
 	});
 
 	it('should not create a playground link if App.svelte is missing', async () => {
-		const result = await session.callTool<{ url: string }>('playground-link', {
+		const result = await client.callTool<{ url: string }>('playground-link', {
 			name: 'My Playground',
 			tailwind: false,
 			files: {

--- a/packages/mcp-server/src/mcp/handlers/tools/playground-link.ts
+++ b/packages/mcp-server/src/mcp/handlers/tools/playground-link.ts
@@ -219,8 +219,8 @@ export function playground_link(server: SvelteMcp) {
 			},
 		},
 		async ({ files, name, tailwind }) => {
-			if (server.ctx.sessionId && server.ctx.custom?.track) {
-				await server.ctx.custom?.track?.(server.ctx.sessionId, 'playground-link');
+			if (server.ctx.custom?.track) {
+				await server.ctx.custom.track(server.ctx.sessionId, 'playground-link');
 			}
 			try {
 				const result = await playground_link_handler({ files, name, tailwind });
@@ -247,8 +247,8 @@ export function playground_link(server: SvelteMcp) {
 				};
 			} catch (e) {
 				const error = e as Error;
-				if (server.ctx.sessionId && server.ctx.custom?.track) {
-					await server.ctx.custom?.track?.(
+				if (server.ctx.custom?.track) {
+					await server.ctx.custom.track(
 						server.ctx.sessionId,
 						'playground-link-error',
 						error.message,

--- a/packages/mcp-server/src/mcp/handlers/tools/svelte-autofixer.test.ts
+++ b/packages/mcp-server/src/mcp/handlers/tools/svelte-autofixer.test.ts
@@ -8,7 +8,7 @@ import { server } from '../../index.js';
 
 const transport = new InMemoryTransport(server);
 
-let session: ReturnType<typeof transport.session>;
+let client: ReturnType<typeof transport.session> | ReturnType<typeof transport.stateless>;
 
 async function autofixer_tool_call(
 	code: string,
@@ -17,7 +17,7 @@ async function autofixer_tool_call(
 	async = false,
 	ctx?: { stdio?: boolean },
 ) {
-	const result = await session.callTool(
+	const result = await client.callTool(
 		'svelte-autofixer',
 		{
 			code,
@@ -36,19 +36,21 @@ async function autofixer_tool_call(
 	return result.structuredContent as any;
 }
 
-describe('svelte-autofixer tool', () => {
+describe.each(['session', 'stateless'])('svelte-autofixer tool - %s', (type) => {
 	beforeEach(async () => {
-		session = transport.session();
-
-		session = transport.session();
-		await session.initialize(
-			'2025-06-18',
-			{},
-			{
-				name: 'test-client',
-				version: '1.0.0',
-			},
-		);
+		if (type === 'session') {
+			client = transport.session();
+			await client.initialize(
+				'2025-06-18',
+				{},
+				{
+					name: 'test-client',
+					version: '1.0.0',
+				},
+			);
+		} else {
+			client = transport.stateless();
+		}
 	});
 
 	it('should add suggestions for js parse errors', async () => {

--- a/packages/mcp-server/src/mcp/handlers/tools/svelte-autofixer.ts
+++ b/packages/mcp-server/src/mcp/handlers/tools/svelte-autofixer.ts
@@ -144,8 +144,8 @@ export function svelte_autofixer(server: SvelteMcp) {
 			desired_svelte_version: desired_svelte_version_unchecked,
 			async,
 		}) => {
-			if (server.ctx.sessionId && server.ctx.custom?.track) {
-				await server.ctx.custom?.track?.(server.ctx.sessionId, 'svelte-autofixer');
+			if (server.ctx.custom?.track) {
+				await server.ctx.custom.track(server.ctx.sessionId, 'svelte-autofixer');
 			}
 
 			// we only do this if we know we are running in stdio mode (only stdio pass the context as true)
@@ -169,8 +169,8 @@ export function svelte_autofixer(server: SvelteMcp) {
 				return tool.structured(content);
 			} catch (e) {
 				const error = e as Error;
-				if (server.ctx.sessionId && server.ctx.custom?.track) {
-					await server.ctx.custom?.track?.(
+				if (server.ctx.custom?.track) {
+					await server.ctx.custom.track(
 						server.ctx.sessionId,
 						'svelte-autofixer-error',
 						error.message,

--- a/packages/mcp-server/src/mcp/index.ts
+++ b/packages/mcp-server/src/mcp/index.ts
@@ -23,7 +23,8 @@ export const server = new McpServer(
 			'This is the official Svelte MCP server. It MUST be used whenever svelte development is involved. It can provide official documentation, code examples and correct your code. After you correct the component call this tool again to confirm all the issues are fixed.',
 	},
 ).withContext<{
-	track?: (sessionId: string, event: string, extra?: string) => Promise<void>;
+	track?: (sessionId: string | undefined, event: string, extra?: string) => Promise<void>;
+	id?: string;
 	stdio?: boolean;
 }>();
 
@@ -34,6 +35,6 @@ setup_resources(server);
 setup_prompts(server);
 
 server.on('initialize', async ({ clientInfo: client_info }) => {
-	if (!server.ctx.custom?.track || !server.ctx.sessionId) return;
+	if (!server.ctx.custom?.track) return;
 	server.ctx.custom.track(server.ctx.sessionId, 'initialize', client_info.name);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ catalogs:
       version: 8.54.0
   opencode:
     '@opencode-ai/plugin':
-      specifier: 1.17.9
-      version: 1.17.9
+      specifier: 1.17.18
+      version: 1.17.18
     '@opentui/core':
       specifier: ^0.4.3
       version: 0.4.3
@@ -421,7 +421,7 @@ importers:
     devDependencies:
       '@opencode-ai/plugin':
         specifier: catalog:opencode
-        version: 1.17.9(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))
+        version: 1.17.18(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))
       '@types/node':
         specifier: catalog:tooling
         version: 24.10.9
@@ -430,6 +430,10 @@ importers:
         version: 1.5.0(valibot@1.2.0(typescript@5.9.3))
 
 packages:
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1221,12 +1225,12 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@opencode-ai/plugin@1.17.9':
-    resolution: {integrity: sha512-RvYsX2k90ew0P3c0R/Jrt6UOdA5CYf4GmYuREDKHx31GSJ25WKg9hrTzkcwCfvPPCpaBc53Qq6Fon9aWr+58ag==}
+  '@opencode-ai/plugin@1.17.18':
+    resolution: {integrity: sha512-tqVBzhTHYUzO0laAmcQeBtT56tXYM5VGUk9V60O+cMx4kkSfac4qEfPVguCGUMJnfcU+u+EPvpME6xmHWoQE8w==}
     peerDependencies:
-      '@opentui/core': '>=0.3.4'
-      '@opentui/keymap': '>=0.3.4'
-      '@opentui/solid': '>=0.3.4'
+      '@opentui/core': '>=0.4.3'
+      '@opentui/keymap': '>=0.4.3'
+      '@opentui/solid': '>=0.4.3'
     peerDependenciesMeta:
       '@opentui/core':
         optional: true
@@ -1235,8 +1239,8 @@ packages:
       '@opentui/solid':
         optional: true
 
-  '@opencode-ai/sdk@1.17.9':
-    resolution: {integrity: sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw==}
+  '@opencode-ai/sdk@1.17.18':
+    resolution: {integrity: sha512-c/C9PhY8PrbcxDY+JIYtOZsrmMD0KzoVvxq+RGUrZ6LQp57SuVBbT4lfwA2G8Se5RNC1N5JtYjiuaXeECnF2SQ==}
 
   '@opentui/core-darwin-arm64@0.4.3':
     resolution: {integrity: sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ==}
@@ -2729,8 +2733,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-beta.74:
-    resolution: {integrity: sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==}
+  effect@4.0.0-beta.83:
+    resolution: {integrity: sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==}
 
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
@@ -3438,6 +3442,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4746,6 +4753,10 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -5666,17 +5677,18 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opencode-ai/plugin@1.17.9(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))':
+  '@opencode-ai/plugin@1.17.18(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))':
     dependencies:
-      '@opencode-ai/sdk': 1.17.9
-      effect: 4.0.0-beta.74
+      '@ai-sdk/provider': 3.0.8
+      '@opencode-ai/sdk': 1.17.18
+      effect: 4.0.0-beta.83
       zod: 4.1.8
     optionalDependencies:
       '@opentui/core': 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/keymap': 0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid': 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
 
-  '@opencode-ai/sdk@1.17.9':
+  '@opencode-ai/sdk@1.17.18':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -6952,7 +6964,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-beta.74:
+  effect@4.0.0-beta.83:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 4.8.0
@@ -7815,6 +7827,8 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@1.0.2:
@@ -8161,7 +8175,7 @@ snapshots:
 
   pnpm-workspace-yaml@1.5.0:
     dependencies:
-      yaml: 2.8.2
+      yaml: 2.9.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9074,7 +9088,7 @@ snapshots:
   yaml-eslint-parser@2.0.0:
     dependencies:
       eslint-visitor-keys: 5.0.0
-      yaml: 2.8.2
+      yaml: 2.9.0
 
   yaml@1.10.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ catalogs:
       version: 1.5.0
     eslint-plugin-svelte:
       specifier: ^3.19.0
-      version: 3.19.0
+      version: 3.14.0
     globals:
       specifier: ^17.0.0
       version: 17.2.0
@@ -95,17 +95,17 @@ catalogs:
       specifier: ^0.1.5
       version: 0.1.5
     '@tmcp/transport-http':
-      specifier: ^0.8.5
-      version: 0.8.5
+      specifier: 0.9.0-next.0
+      version: 0.9.0-next.0
     '@tmcp/transport-in-memory':
-      specifier: ^0.0.6
-      version: 0.0.6
+      specifier: 0.1.0-next.0
+      version: 0.1.0-next.0
     '@tmcp/transport-stdio':
-      specifier: ^0.4.2
-      version: 0.4.2
+      specifier: 0.5.0-next.0
+      version: 0.5.0-next.0
     tmcp:
-      specifier: ^1.19.3
-      version: 1.19.3
+      specifier: 1.20.0-next.1
+      version: 1.20.0-next.1
   tooling:
     '@changesets/changelog-github':
       specifier: 1.0.0-next.6
@@ -234,13 +234,13 @@ importers:
         version: link:../../packages/mcp-server
       '@tmcp/transport-http':
         specifier: catalog:tmcp
-        version: 0.8.5(tmcp@1.19.3(typescript@5.9.3))
+        version: 0.9.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
       '@vercel/analytics':
         specifier: catalog:tooling
         version: 2.0.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.54.0))(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.54.0))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)))(react@18.3.1)(svelte@5.56.1(@typescript-eslint/types@8.54.0))
       tmcp:
         specifier: catalog:tmcp
-        version: 1.19.3(typescript@5.9.3)
+        version: 1.20.0-next.1(typescript@5.9.3)
     devDependencies:
       '@eslint/compat':
         specifier: catalog:lint
@@ -310,10 +310,10 @@ importers:
         version: 6.0.0(hono@4.11.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.1.8)
       '@tmcp/adapter-valibot':
         specifier: catalog:tmcp
-        version: 0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+        version: 0.1.5(tmcp@1.20.0-next.1(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
       '@tmcp/transport-in-memory':
         specifier: catalog:tmcp
-        version: 0.0.6(tmcp@1.19.3(typescript@5.9.3))
+        version: 0.1.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
       '@typescript-eslint/parser':
         specifier: catalog:lint
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
@@ -331,7 +331,7 @@ importers:
         version: 1.7.1(svelte@5.56.1(@typescript-eslint/types@8.54.0))
       tmcp:
         specifier: catalog:tmcp
-        version: 1.19.3(typescript@5.9.3)
+        version: 1.20.0-next.1(typescript@5.9.3)
       ts-blank-space:
         specifier: catalog:tooling
         version: 0.7.0
@@ -374,14 +374,14 @@ importers:
         version: 1.8.1
       tmcp:
         specifier: catalog:tmcp
-        version: 1.19.3(typescript@5.9.3)
+        version: 1.20.0-next.1(typescript@5.9.3)
     devDependencies:
       '@sveltejs/mcp-server':
         specifier: workspace:^
         version: link:../mcp-server
       '@tmcp/transport-stdio':
         specifier: catalog:tmcp
-        version: 0.4.2(tmcp@1.19.3(typescript@5.9.3))
+        version: 0.5.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
       '@types/node':
         specifier: catalog:tooling
         version: 24.10.9
@@ -2074,29 +2074,29 @@ packages:
       tmcp: ^1.17.0
       valibot: ^1.1.0
 
-  '@tmcp/session-manager@0.2.1':
-    resolution: {integrity: sha512-DOGy9LfufXCy1wfpGHZ6qPSDQtRnTVwOb71+41ffovTqzLMZlK3iLK/LIsekHxIiku+iIAUiqEKN+DHbqEm8IA==}
+  '@tmcp/session-manager@0.3.0-next.0':
+    resolution: {integrity: sha512-w5KF92ijShe38lLZSoiOJjndqocsjJYaiNkLVnlR/sLG4hArEKe3ZQ262CN7uPzj8g9N4mzJdcSGC2SC7vNv4Q==}
     peerDependencies:
-      tmcp: ^1.16.3
+      tmcp: ^1.20.0-next.0 || ^1.20.0
 
-  '@tmcp/transport-http@0.8.5':
-    resolution: {integrity: sha512-qQLqiCTtbxtTSswqOn/782df7O57RxI/yLUtCDQ++kHEhbmDUc8glmmtGJ3mrb7yPSPoM5VF2Pc2Q5cA6quzLA==}
+  '@tmcp/transport-http@0.9.0-next.0':
+    resolution: {integrity: sha512-rmu4vEW92msbIIbxK0kJvJLCCeLrgCk844jVWlrQ6I0/tKqo6J8yMEtCqJItjltShwt1I3BJwwsVXj9yUaCK5A==}
     peerDependencies:
-      '@tmcp/auth': ^0.3.3 || ^0.4.0
-      tmcp: ^1.18.0
+      '@tmcp/auth': ^0.3.3 || ^0.4.0 || ^0.5.0-next.0
+      tmcp: ^1.20.0-next.0 || ^1.20.0
     peerDependenciesMeta:
       '@tmcp/auth':
         optional: true
 
-  '@tmcp/transport-in-memory@0.0.6':
-    resolution: {integrity: sha512-j+xcfQa7ksiIkA/8s3SAsTnM3GeZTd+X8F++Mv/tAT91+UkCzyhemPz0MqW7i1ruxJyIWooOB6JhWCsyF+LvhA==}
+  '@tmcp/transport-in-memory@0.1.0-next.0':
+    resolution: {integrity: sha512-X+ovwDdAdoyowgNgQcEOGiHbgrWVFDT/RaF+iBL1pujkv2awQMBpi69RY+F2fH/1sw+v4ogj8YGdNqJD2dyv/Q==}
     peerDependencies:
-      tmcp: ^1.17.0
+      tmcp: ^1.20.0-next.0 || ^1.20.0
 
-  '@tmcp/transport-stdio@0.4.2':
-    resolution: {integrity: sha512-OLVLJzUXAKsCvenkjPf5ygli9ZcbEv3Lcei/ry+DB4T1NzvDc1oU3m41zYtHhAmbES1h6om3T9f/zonBSDFMRQ==}
+  '@tmcp/transport-stdio@0.5.0-next.0':
+    resolution: {integrity: sha512-0+U0DPYg97LFVzEK1sEyvvNBX8GSYpehlUKxvjHn9HqFEa9zpMvL/m5nWeJD5zxra+kOKllHeRAw7eyZK/Szew==}
     peerDependencies:
-      tmcp: ^1.16.3
+      tmcp: ^1.20.0-next.0 || ^1.20.0
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -4317,8 +4317,8 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
-  tmcp@1.19.3:
-    resolution: {integrity: sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==}
+  tmcp@1.20.0-next.1:
+    resolution: {integrity: sha512-InQcjBBHgZvcQvEIK86CtFZFl/Tq2OO8ry8mWynn7uHvO7BCYdk56rzoRImFK5MIJJ8k0L0a/z7kL9YOHPQUaw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -6295,31 +6295,34 @@ snapshots:
       vite: 7.3.1(@types/node@24.10.9)(yaml@2.9.0)
       vitefu: 1.1.1(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0))
 
-  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.20.0-next.1(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.9.3))
-      tmcp: 1.19.3(typescript@5.9.3)
+      tmcp: 1.20.0-next.1(typescript@5.9.3)
       valibot: 1.2.0(typescript@5.9.3)
 
-  '@tmcp/session-manager@0.2.1(tmcp@1.19.3(typescript@5.9.3))':
-    dependencies:
-      tmcp: 1.19.3(typescript@5.9.3)
-
-  '@tmcp/transport-http@0.8.5(tmcp@1.19.3(typescript@5.9.3))':
-    dependencies:
-      '@tmcp/session-manager': 0.2.1(tmcp@1.19.3(typescript@5.9.3))
-      esm-env: 1.2.2
-      tmcp: 1.19.3(typescript@5.9.3)
-
-  '@tmcp/transport-in-memory@0.0.6(tmcp@1.19.3(typescript@5.9.3))':
+  '@tmcp/session-manager@0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
     dependencies:
       json-rpc-2.0: 1.7.1
-      tmcp: 1.19.3(typescript@5.9.3)
+      tmcp: 1.20.0-next.1(typescript@5.9.3)
 
-  '@tmcp/transport-stdio@0.4.2(tmcp@1.19.3(typescript@5.9.3))':
+  '@tmcp/transport-http@0.9.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
     dependencies:
-      tmcp: 1.19.3(typescript@5.9.3)
+      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+      esm-env: 1.2.2
+      tmcp: 1.20.0-next.1(typescript@5.9.3)
+
+  '@tmcp/transport-in-memory@0.1.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+      json-rpc-2.0: 1.7.1
+      tmcp: 1.20.0-next.1(typescript@5.9.3)
+
+  '@tmcp/transport-stdio@0.5.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+      tmcp: 1.20.0-next.1(typescript@5.9.3)
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -8720,7 +8723,7 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
-  tmcp@1.19.3(typescript@5.9.3):
+  tmcp@1.20.0-next.1(typescript@5.9.3):
     dependencies:
       '@standard-schema/spec': 1.1.0
       json-rpc-2.0: 1.7.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,10 +37,10 @@ catalogs:
     svelte-check: ^4.0.0
   tmcp:
     '@tmcp/adapter-valibot': ^0.1.5
-    '@tmcp/transport-http': ^0.8.5
-    '@tmcp/transport-in-memory': ^0.0.6
-    '@tmcp/transport-stdio': ^0.4.2
-    tmcp: ^1.19.3
+    '@tmcp/transport-http': 0.9.0-next.0
+    '@tmcp/transport-in-memory': 0.1.0-next.0
+    '@tmcp/transport-stdio': 0.5.0-next.0
+    tmcp: 1.20.0-next.1
   tooling:
     '@changesets/changelog-github': 1.0.0-next.6
     '@changesets/cli': ^2.29.7
@@ -72,5 +72,7 @@ minimumReleaseAgeExclude:
   - prettier-plugin-svelte
   - svelte-check
   - esm-env
+  - 'tmcp'
+  - '@tmcp/*'
 
 useNodeVersion: 22.22.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,8 @@ catalogs:
     vite-plugin-devtools-json: ^1.0.0
     vitest: ^4.0.0
     zimmerframe: ^1.1.4
+  conflicts_opencode_1_17_18:
+    '@opencode-ai/plugin': 1.17.18
 engineStrict: true
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalogs:
     svelte-eslint-parser: ^1.7.1
     typescript-eslint: ^8.44.0
   opencode:
-    '@opencode-ai/plugin': 1.17.9
+    '@opencode-ai/plugin': 1.17.18
     '@opentui/core': ^0.4.3
     '@opentui/keymap': ^0.4.3
     '@opentui/solid': ^0.4.3
@@ -61,8 +61,6 @@ catalogs:
     vite-plugin-devtools-json: ^1.0.0
     vitest: ^4.0.0
     zimmerframe: ^1.1.4
-  conflicts_opencode_1_17_18:
-    '@opencode-ai/plugin': 1.17.18
 engineStrict: true
 minimumReleaseAge: 2880
 minimumReleaseAgeExclude:


### PR DESCRIPTION
The new version of the MCP protocol has been released, and I recently released a new version of `tmcp` supporting it.

Everything should work in a back compatible way, but this way we can already support the new version of the protocol in case some client decides to only support that (considering how annoying it is to support both, I can see how a few might decide that).

For the moment I'm using the next version, but I plan to publish a new version of `tmcp` as soon as I battle test this one a bit... I've already done a bit of testing and especially for our use case (simple tool calls) it should be absolutely fine.