### PR TITLE
chore: use stdio as default server

### DIFF
--- a/.changeset/odd-goats-attend.md
+++ b/.changeset/odd-goats-attend.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/opencode': patch
+---
+
+chore: use stdio as default server

--- a/.changeset/stdio-plugin-defaults.md
+++ b/.changeset/stdio-plugin-defaults.md
@@ -1,0 +1,5 @@
+---
+'@sveltejs/opencode': patch
+---
+
+Default the Svelte MCP server to the local stdio transport.

--- a/documentation/docs/30-mcp/20-local-setup.md
+++ b/documentation/docs/30-mcp/20-local-setup.md
@@ -20,6 +20,8 @@ claude mcp add -t stdio -s [scope] svelte -- npx -y @sveltejs/mcp
 
 The `[scope]` must be `user`, `project` or `local`.
 
+Alternatively, install the `svelte` plugin from [the Svelte Claude Code Marketplace](claude-plugin) to configure the local server along with useful [skills](skills).
+
 ## Claude Desktop
 
 In the Settings > Developer section, click on Edit Config. It will open the folder with a `claude_desktop_config.json` file in it. Edit the file to include the following configuration:

--- a/documentation/docs/30-mcp/30-remote-setup.md
+++ b/documentation/docs/30-mcp/30-remote-setup.md
@@ -4,6 +4,8 @@ title: Remote setup
 
 The remote version of the MCP server is available at `https://mcp.svelte.dev/mcp`.
 
+The Svelte team does not log, store, or inspect code sent to the remote server.
+
 Here's how to set it up in some common MCP clients:
 
 ## Claude Code
@@ -16,8 +18,6 @@ claude mcp add -t http -s [scope] svelte https://mcp.svelte.dev/mcp
 
 You can choose your preferred `scope` (it must be `user`, `project` or `local`) and `name`.
 
-If you prefer you can also install the `svelte` plugin in [the Svelte Claude Code Marketplace](claude-plugin) that will give you both the remote server and useful [skills](skills).
-
 ## Claude Desktop
 
 - Open Settings > Connectors
@@ -28,7 +28,7 @@ If you prefer you can also install the `svelte` plugin in [the Svelte Claude Cod
 
 ## Codex CLI
 
-You can automatically configure the MCP server using the [Codex plugin](codex-plugin) (recommended). If you prefer to configure the MCP server manually, add the following to your `config.toml` (which defaults to `~/.codex/config.toml`, but refer to [the configuration documentation](https://github.com/openai/codex/blob/main/docs/config.md) for more advanced setups):
+Add the following to your `config.toml` (which defaults to `~/.codex/config.toml`, but refer to [the configuration documentation](https://github.com/openai/codex/blob/main/docs/config.md) for more advanced setups):
 
 ```toml
 experimental_use_rmcp_client = true
@@ -38,7 +38,7 @@ url = "https://mcp.svelte.dev/mcp"
 
 ## Copilot CLI
 
-You can automatically configure the MCP server using the [Copilot plugin](copilot-plugin) (recommended). If you prefer to configure the MCP server manually, use the Copilot CLI to interactively add the MCP server:
+Use the Copilot CLI to interactively add the MCP server:
 
 ```bash
 /mcp add
@@ -72,7 +72,7 @@ To use the remote MCP version in Antigravity CLI, create or edit `~/.gemini/conf
 
 ## OpenCode
 
-You can automatically configure the MCP server using the [OpenCode plugin](opencode-plugin) (recommended). If you prefer to configure the MCP server manually, run:
+Run:
 
 ```bash
 opencode mcp add
@@ -106,7 +106,7 @@ opencode mcp add
 
 ## Cursor
 
-You can automatically configure the MCP server using the [Cursor plugin](cursor-plugin) (recommended). If you prefer to configure the MCP server manually you can:
+To configure the remote server:
 
 - Open the command palette
 - Select "View: Open MCP Settings"

--- a/documentation/docs/60-plugins/10-claude-plugin.md
+++ b/documentation/docs/60-plugins/10-claude-plugin.md
@@ -4,7 +4,7 @@ title: Claude Code
 
 The open source [repository](https://github.com/sveltejs/ai-tools) containing the code for the MCP server is also a Claude Code [plugin marketplace](https://code.claude.com/docs/en/discover-plugins).
 
-The marketplace allows you to install the `svelte` plugin which will give you the remote MCP server, [skills](skills) to instruct the LLM on how to properly write Svelte 5 code, and a specialized agent for editing Svelte files.
+The marketplace allows you to install the `svelte` plugin which will give you the local stdio MCP server, [skills](skills) to instruct the LLM on how to properly write Svelte 5 code, and a specialized agent for editing Svelte files.
 
 If possible, we recommend that you instruct the LLM to execute MCP calls with the agent (you can explicitly mention an agent in your message to delegate work to it) when creating or editing `.svelte` files or `.svelte.ts`/`.svelte.js` modules — this will help save context by handling Svelte-specific tasks more efficiently.
 

--- a/documentation/docs/60-plugins/20-opencode-plugin.md
+++ b/documentation/docs/60-plugins/20-opencode-plugin.md
@@ -47,7 +47,7 @@ By default, the MCP server, subagent, skills, instructions, and automatic update
 {
 	"$schema": "https://svelte.dev/opencode/schema.json",
 	"mcp": {
-		"type": "remote", // or "local" — defaults to remote
+		"type": "local", // or "remote"; defaults to local
 		"enabled": true
 	},
 	"subagent": {

--- a/documentation/docs/60-plugins/30-cursor-plugin.md
+++ b/documentation/docs/60-plugins/30-cursor-plugin.md
@@ -4,7 +4,7 @@ title: Cursor
 
 Cursor has a [plugin system](https://cursor.com/docs/plugins) that can bundle rules, skills, agents, commands, MCP servers, and hooks.
 
-The Svelte plugin gives you the remote Svelte MCP server, Cursor [skills](skills), an always-on rule that tells the model how to use the Svelte MCP tools correctly, and the `svelte-file-editor` subagent for working on `.svelte` files and `.svelte.ts`/`.svelte.js` modules. The source is available in the [`sveltejs/ai-tools`](https://github.com/sveltejs/ai-tools/tree/main/plugins/cursor/svelte) repo.
+The Svelte plugin gives you the local stdio Svelte MCP server, Cursor [skills](skills), an always-on rule that tells the model how to use the Svelte MCP tools correctly, and the `svelte-file-editor` subagent for working on `.svelte` files and `.svelte.ts`/`.svelte.js` modules. The source is available in the [`sveltejs/ai-tools`](https://github.com/sveltejs/ai-tools/tree/main/plugins/cursor/svelte) repo.
 
 ## Installation
 

--- a/documentation/docs/60-plugins/40-copilot-plugin.md
+++ b/documentation/docs/60-plugins/40-copilot-plugin.md
@@ -4,7 +4,7 @@ title: GitHub Copilot CLI
 
 The open source [repository](https://github.com/sveltejs/ai-tools) containing the code for the MCP server is also a GitHub Copilot CLI [plugin marketplace](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing).
 
-The marketplace allows you to install the `svelte` plugin which will give you the remote MCP server, [skills](skills) to instruct the LLM on how to properly write Svelte 5 code, and a specialized agent for editing Svelte files.
+The marketplace allows you to install the `svelte` plugin which will give you the local stdio MCP server, [skills](skills) to instruct the LLM on how to properly write Svelte 5 code, and a specialized agent for editing Svelte files.
 
 If possible, we recommend that you instruct the LLM to execute MCP calls with the agent (you can explicitly mention an agent in your message to delegate work to it) when creating or editing `.svelte` files or `.svelte.ts`/`.svelte.js` modules — this will help save context by handling Svelte-specific tasks more efficiently.
 

--- a/documentation/docs/60-plugins/50-codex-plugin.md
+++ b/documentation/docs/60-plugins/50-codex-plugin.md
@@ -4,7 +4,7 @@ title: Codex CLI
 
 The open source [repository](https://github.com/sveltejs/ai-tools) containing the code for the MCP server is also a Codex CLI [plugin marketplace](https://developers.openai.com/codex/plugins).
 
-The marketplace allows you to install the `svelte` plugin which will give you the remote MCP server, [skills](skills) to instruct the LLM on how to properly write Svelte 5 code, and a specialized agent for editing Svelte files.
+The marketplace allows you to install the `svelte` plugin which will give you the local stdio MCP server, [skills](skills) to instruct the LLM on how to properly write Svelte 5 code, and a specialized agent for editing Svelte files.
 
 If possible, we recommend that you instruct the LLM to execute MCP calls with the agent (you can explicitly mention an agent in your message to delegate work to it) when creating or editing `.svelte` files or `.svelte.ts`/`.svelte.js` modules — this will help save context by handling Svelte-specific tasks more efficiently.
 

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -53,7 +53,7 @@ Create `svelte.json` to customize how the plugin configures MCP, the Svelte suba
 {
 	"$schema": "https://svelte.dev/opencode/schema.json",
 	"mcp": {
-		"type": "remote",
+		"type": "local",
 		"enabled": true
 	},
 	"subagent": {
@@ -87,7 +87,7 @@ Automatic updates are enabled by default. When a newer version is detected, the 
 
 If omitted, the plugin uses these defaults:
 
-- `mcp.type`: `"remote"`
+- `mcp.type`: `"local"`
 - `mcp.enabled`: `true`
 - `subagent.enabled`: `true`
 - `subagent.agents`: `{}`
@@ -99,7 +99,7 @@ If omitted, the plugin uses these defaults:
 
 | Option                                           | Type                  | Default    | Description                                                                                    |
 | ------------------------------------------------ | --------------------- | ---------- | ---------------------------------------------------------------------------------------------- |
-| `mcp.type`                                       | `"remote" \| "local"` | `"remote"` | Use `https://mcp.svelte.dev/mcp` (`remote`) or run `@sveltejs/mcp` via `npx` (`local`).        |
+| `mcp.type`                                       | `"remote" \| "local"` | `"local"`  | Run `@sveltejs/mcp` via `npx` (`local`) or use `https://mcp.svelte.dev/mcp` (`remote`).        |
 | `mcp.enabled`                                    | `boolean`             | `true`     | Enable or disable the Svelte MCP server entry.                                                 |
 | `subagent.enabled`                               | `boolean`             | `true`     | Enable or disable registration of the `svelte-file-editor` subagent.                           |
 | `subagent.agents.svelte-file-editor.model`       | `string`              | main agent | Override the model used by the Svelte file editor subagent.                                    |

--- a/packages/opencode/config.js
+++ b/packages/opencode/config.js
@@ -29,7 +29,7 @@ const agent_config_schema = v.object({
 
 const default_config = {
 	mcp: {
-		type: /** @type {'remote' | 'local'} */ ('remote'),
+		type: /** @type {'remote' | 'local'} */ ('local'),
 		enabled: true,
 	},
 	subagent: {
@@ -54,7 +54,7 @@ export const config_schema = v.object({
 			}),
 		),
 		v.description(
-			"Configuration for the MCP. You can chose if it should be enabled or not and the transport to use 'remote' (default) and 'local'.",
+			"Configuration for the MCP. You can choose whether it is enabled and which transport to use: 'local' (default) or 'remote'.",
 		),
 	),
 	subagent: v.pipe(

--- a/packages/opencode/schema.json
+++ b/packages/opencode/schema.json
@@ -15,7 +15,7 @@
 				}
 			},
 			"required": [],
-			"description": "Configuration for the MCP. You can chose if it should be enabled or not and the transport to use 'remote' (default) and 'local'."
+			"description": "Configuration for the MCP. You can choose whether it is enabled and which transport to use: 'local' (default) or 'remote'."
 		},
 		"subagent": {
 			"type": "object",

--- a/packages/opencode/tui.jsx
+++ b/packages/opencode/tui.jsx
@@ -214,7 +214,7 @@ const tui = async (api) => {
 			}
 			/** @param {'remote' | 'local'} value */
 			function radio(value) {
-				return (config.mcp?.type ?? 'remote') === value ? '(*)' : '( )';
+				return (config.mcp?.type ?? 'local') === value ? '(*)' : '( )';
 			}
 			api.ui.dialog.replace(() => (
 				<api.ui.DialogSelect

--- a/plugins/claude/svelte/.claude-plugin/plugin.json
+++ b/plugins/claude/svelte/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelte",
 	"description": "A plugin for all things related to Svelte development, MCP, skills, and more.",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"author": {
 		"name": "Svelte"
 	},

--- a/plugins/claude/svelte/.mcp.json
+++ b/plugins/claude/svelte/.mcp.json
@@ -1,8 +1,9 @@
 {
 	"mcpServers": {
 		"svelte": {
-			"type": "http",
-			"url": "https://mcp.svelte.dev/mcp"
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "@sveltejs/mcp"]
 		}
 	}
 }

--- a/plugins/cursor/svelte/.cursor-plugin/plugin.json
+++ b/plugins/cursor/svelte/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "svelte",
 	"description": "A plugin for all things related to Svelte development, MCP, skills, and more.",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"author": {
 		"name": "Svelte"
 	},

--- a/plugins/cursor/svelte/.mcp.json
+++ b/plugins/cursor/svelte/.mcp.json
@@ -1,8 +1,9 @@
 {
 	"mcpServers": {
 		"svelte": {
-			"type": "http",
-			"url": "https://mcp.svelte.dev/mcp"
+			"type": "stdio",
+			"command": "npx",
+			"args": ["-y", "@sveltejs/mcp"]
 		}
 	}
 }


### PR DESCRIPTION
Someone complained about the default for plugins to sent the code to a remote server.

While it's pretty silly because we don't log anything and the code is not stored anywhere having the `stdio` be the default is also fine.

This PR switches the default AND adds a line for the remote server configuration to reassure that no logging or reading is done.