### PR TITLE
chore: add discover track

### DIFF
--- a/packages/mcp-server/src/mcp/index.ts
+++ b/packages/mcp-server/src/mcp/index.ts
@@ -38,3 +38,8 @@ server.on('initialize', async ({ clientInfo: client_info }) => {
 	if (!server.ctx.custom?.track) return;
 	server.ctx.custom.track(server.ctx.sessionId, 'initialize', client_info.name);
 });
+
+server.on('discover', ({ _meta: { 'io.modelcontextprotocol/clientInfo': client_info } }) => {
+	if (!server.ctx.custom?.track || !client_info) return;
+	server.ctx.custom.track(undefined, 'discover', client_info.name);
+});

--- a/packages/mcp-server/src/mcp/index.ts
+++ b/packages/mcp-server/src/mcp/index.ts
@@ -39,7 +39,9 @@ server.on('initialize', async ({ clientInfo: client_info }) => {
 	server.ctx.custom.track(server.ctx.sessionId, 'initialize', client_info.name);
 });
 
-server.on('discover', ({ _meta: { 'io.modelcontextprotocol/clientInfo': client_info } }) => {
+server.on('discover', (request) => {
+	if (!request?._meta) return;
+	const { 'io.modelcontextprotocol/clientInfo': client_info } = request._meta;
 	if (!server.ctx.custom?.track || !client_info) return;
 	server.ctx.custom.track(undefined, 'discover', client_info.name);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ catalogs:
       specifier: 0.5.0-next.0
       version: 0.5.0-next.0
     tmcp:
-      specifier: 1.20.0-next.1
-      version: 1.20.0-next.1
+      specifier: 1.20.0-next.2
+      version: 1.20.0-next.2
   tooling:
     '@changesets/changelog-github':
       specifier: 1.0.0-next.6
@@ -234,13 +234,13 @@ importers:
         version: link:../../packages/mcp-server
       '@tmcp/transport-http':
         specifier: catalog:tmcp
-        version: 0.9.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+        version: 0.9.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
       '@vercel/analytics':
         specifier: catalog:tooling
         version: 2.0.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.54.0))(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.54.0))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)))(react@18.3.1)(svelte@5.56.1(@typescript-eslint/types@8.54.0))
       tmcp:
         specifier: catalog:tmcp
-        version: 1.20.0-next.1(typescript@5.9.3)
+        version: 1.20.0-next.2(typescript@5.9.3)
     devDependencies:
       '@eslint/compat':
         specifier: catalog:lint
@@ -310,10 +310,10 @@ importers:
         version: 6.0.0(hono@4.11.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.1.8)
       '@tmcp/adapter-valibot':
         specifier: catalog:tmcp
-        version: 0.1.5(tmcp@1.20.0-next.1(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+        version: 0.1.5(tmcp@1.20.0-next.2(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
       '@tmcp/transport-in-memory':
         specifier: catalog:tmcp
-        version: 0.1.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+        version: 0.1.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
       '@typescript-eslint/parser':
         specifier: catalog:lint
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
@@ -331,7 +331,7 @@ importers:
         version: 1.7.1(svelte@5.56.1(@typescript-eslint/types@8.54.0))
       tmcp:
         specifier: catalog:tmcp
-        version: 1.20.0-next.1(typescript@5.9.3)
+        version: 1.20.0-next.2(typescript@5.9.3)
       ts-blank-space:
         specifier: catalog:tooling
         version: 0.7.0
@@ -374,14 +374,14 @@ importers:
         version: 1.8.1
       tmcp:
         specifier: catalog:tmcp
-        version: 1.20.0-next.1(typescript@5.9.3)
+        version: 1.20.0-next.2(typescript@5.9.3)
     devDependencies:
       '@sveltejs/mcp-server':
         specifier: workspace:^
         version: link:../mcp-server
       '@tmcp/transport-stdio':
         specifier: catalog:tmcp
-        version: 0.5.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+        version: 0.5.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
       '@types/node':
         specifier: catalog:tooling
         version: 24.10.9
@@ -405,7 +405,7 @@ importers:
         version: 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/keymap':
         specifier: catalog:opencode
-        version: 0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+        version: 0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid':
         specifier: catalog:opencode
         version: 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
@@ -421,7 +421,7 @@ importers:
     devDependencies:
       '@opencode-ai/plugin':
         specifier: catalog:opencode
-        version: 1.17.18(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))
+        version: 1.17.18(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))
       '@types/node':
         specifier: catalog:tooling
         version: 24.10.9
@@ -4324,8 +4324,8 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
-  tmcp@1.20.0-next.1:
-    resolution: {integrity: sha512-InQcjBBHgZvcQvEIK86CtFZFl/Tq2OO8ry8mWynn7uHvO7BCYdk56rzoRImFK5MIJJ8k0L0a/z7kL9YOHPQUaw==}
+  tmcp@1.20.0-next.2:
+    resolution: {integrity: sha512-q2idHdSvQiVwVO+CaBFNeH2jpZQ6dyH5LufH7b+eGD9TT0o5yf79R0/TFpUcvaCAoFVxnGeXOZXJhAFU54IIzw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5677,7 +5677,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@opencode-ai/plugin@1.17.18(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))':
+  '@opencode-ai/plugin@1.17.18(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@opencode-ai/sdk': 1.17.18
@@ -5685,7 +5685,7 @@ snapshots:
       zod: 4.1.8
     optionalDependencies:
       '@opentui/core': 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
-      '@opentui/keymap': 0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
+      '@opentui/keymap': 0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       '@opentui/solid': 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
 
   '@opencode-ai/sdk@1.17.18':
@@ -5736,12 +5736,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(react@18.3.1)(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
+  '@opentui/keymap@0.4.3(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)':
     dependencies:
       '@opentui/core': 0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10)
     optionalDependencies:
       '@opentui/solid': 0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10)
-      react: 18.3.1
       solid-js: 1.9.12
     transitivePeerDependencies:
       - typescript
@@ -6307,34 +6306,34 @@ snapshots:
       vite: 7.3.1(@types/node@24.10.9)(yaml@2.9.0)
       vitefu: 1.1.1(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0))
 
-  '@tmcp/adapter-valibot@0.1.5(tmcp@1.20.0-next.1(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.20.0-next.2(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.9.3))
-      tmcp: 1.20.0-next.1(typescript@5.9.3)
+      tmcp: 1.20.0-next.2(typescript@5.9.3)
       valibot: 1.2.0(typescript@5.9.3)
 
-  '@tmcp/session-manager@0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
+  '@tmcp/session-manager@0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
     dependencies:
       json-rpc-2.0: 1.7.1
-      tmcp: 1.20.0-next.1(typescript@5.9.3)
+      tmcp: 1.20.0-next.2(typescript@5.9.3)
 
-  '@tmcp/transport-http@0.9.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
+  '@tmcp/transport-http@0.9.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
     dependencies:
-      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
       esm-env: 1.2.2
-      tmcp: 1.20.0-next.1(typescript@5.9.3)
+      tmcp: 1.20.0-next.2(typescript@5.9.3)
 
-  '@tmcp/transport-in-memory@0.1.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
+  '@tmcp/transport-in-memory@0.1.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
     dependencies:
-      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
+      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
       json-rpc-2.0: 1.7.1
-      tmcp: 1.20.0-next.1(typescript@5.9.3)
+      tmcp: 1.20.0-next.2(typescript@5.9.3)
 
-  '@tmcp/transport-stdio@0.5.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))':
+  '@tmcp/transport-stdio@0.5.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
     dependencies:
-      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.1(typescript@5.9.3))
-      tmcp: 1.20.0-next.1(typescript@5.9.3)
+      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
+      tmcp: 1.20.0-next.2(typescript@5.9.3)
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -8737,7 +8736,7 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
-  tmcp@1.20.0-next.1(typescript@5.9.3):
+  tmcp@1.20.0-next.2(typescript@5.9.3):
     dependencies:
       '@standard-schema/spec': 1.1.0
       json-rpc-2.0: 1.7.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,17 +95,17 @@ catalogs:
       specifier: ^0.1.5
       version: 0.1.5
     '@tmcp/transport-http':
-      specifier: 0.9.0-next.0
-      version: 0.9.0-next.0
+      specifier: ^0.9.0
+      version: 0.9.0
     '@tmcp/transport-in-memory':
-      specifier: 0.1.0-next.0
-      version: 0.1.0-next.0
+      specifier: ^0.1.0
+      version: 0.1.0
     '@tmcp/transport-stdio':
-      specifier: 0.5.0-next.0
-      version: 0.5.0-next.0
+      specifier: ^0.5.0
+      version: 0.5.0
     tmcp:
-      specifier: 1.20.0-next.2
-      version: 1.20.0-next.2
+      specifier: ^1.20.0
+      version: 1.20.0
   tooling:
     '@changesets/changelog-github':
       specifier: 1.0.0-next.6
@@ -234,13 +234,13 @@ importers:
         version: link:../../packages/mcp-server
       '@tmcp/transport-http':
         specifier: catalog:tmcp
-        version: 0.9.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
+        version: 0.9.0(tmcp@1.20.0(typescript@5.9.3))
       '@vercel/analytics':
         specifier: catalog:tooling
         version: 2.0.1(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.1(@typescript-eslint/types@8.54.0))(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)))(svelte@5.56.1(@typescript-eslint/types@8.54.0))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0)))(react@18.3.1)(svelte@5.56.1(@typescript-eslint/types@8.54.0))
       tmcp:
         specifier: catalog:tmcp
-        version: 1.20.0-next.2(typescript@5.9.3)
+        version: 1.20.0(typescript@5.9.3)
     devDependencies:
       '@eslint/compat':
         specifier: catalog:lint
@@ -310,10 +310,10 @@ importers:
         version: 6.0.0(hono@4.11.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.1.8)
       '@tmcp/adapter-valibot':
         specifier: catalog:tmcp
-        version: 0.1.5(tmcp@1.20.0-next.2(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+        version: 0.1.5(tmcp@1.20.0(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
       '@tmcp/transport-in-memory':
         specifier: catalog:tmcp
-        version: 0.1.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
+        version: 0.1.0(tmcp@1.20.0(typescript@5.9.3))
       '@typescript-eslint/parser':
         specifier: catalog:lint
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
@@ -331,7 +331,7 @@ importers:
         version: 1.7.1(svelte@5.56.1(@typescript-eslint/types@8.54.0))
       tmcp:
         specifier: catalog:tmcp
-        version: 1.20.0-next.2(typescript@5.9.3)
+        version: 1.20.0(typescript@5.9.3)
       ts-blank-space:
         specifier: catalog:tooling
         version: 0.7.0
@@ -374,14 +374,14 @@ importers:
         version: 1.8.1
       tmcp:
         specifier: catalog:tmcp
-        version: 1.20.0-next.2(typescript@5.9.3)
+        version: 1.20.0(typescript@5.9.3)
     devDependencies:
       '@sveltejs/mcp-server':
         specifier: workspace:^
         version: link:../mcp-server
       '@tmcp/transport-stdio':
         specifier: catalog:tmcp
-        version: 0.5.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
+        version: 0.5.0(tmcp@1.20.0(typescript@5.9.3))
       '@types/node':
         specifier: catalog:tooling
         version: 24.10.9
@@ -2078,13 +2078,13 @@ packages:
       tmcp: ^1.17.0
       valibot: ^1.1.0
 
-  '@tmcp/session-manager@0.3.0-next.0':
-    resolution: {integrity: sha512-w5KF92ijShe38lLZSoiOJjndqocsjJYaiNkLVnlR/sLG4hArEKe3ZQ262CN7uPzj8g9N4mzJdcSGC2SC7vNv4Q==}
+  '@tmcp/session-manager@0.3.0':
+    resolution: {integrity: sha512-L16r8qlzXUoS0ec7kuap1P1nQorCcZHHUFe7UGijwwrfBRXB0hFnfC+/BM1PVdGlM7Ade8YxomecybQN5imYXA==}
     peerDependencies:
       tmcp: ^1.20.0-next.0 || ^1.20.0
 
-  '@tmcp/transport-http@0.9.0-next.0':
-    resolution: {integrity: sha512-rmu4vEW92msbIIbxK0kJvJLCCeLrgCk844jVWlrQ6I0/tKqo6J8yMEtCqJItjltShwt1I3BJwwsVXj9yUaCK5A==}
+  '@tmcp/transport-http@0.9.0':
+    resolution: {integrity: sha512-AcHg8frvReVBtSIy3Wps9EBN2nfdq1cC82UzRoNGy5LoNDGe5xDkeYcgcqR9Gyz9uYcfO1evbhZIVtRzmQqW2Q==}
     peerDependencies:
       '@tmcp/auth': ^0.3.3 || ^0.4.0 || ^0.5.0-next.0
       tmcp: ^1.20.0-next.0 || ^1.20.0
@@ -2092,13 +2092,13 @@ packages:
       '@tmcp/auth':
         optional: true
 
-  '@tmcp/transport-in-memory@0.1.0-next.0':
-    resolution: {integrity: sha512-X+ovwDdAdoyowgNgQcEOGiHbgrWVFDT/RaF+iBL1pujkv2awQMBpi69RY+F2fH/1sw+v4ogj8YGdNqJD2dyv/Q==}
+  '@tmcp/transport-in-memory@0.1.0':
+    resolution: {integrity: sha512-EsFmGCTv/L8tyGgFhFvFVZR6Cd6CWBj99VzafuwUCFVQvoGgr0bfDKW0MY26hTW+pq4Zy+tWFB/PGnFCpTLg+Q==}
     peerDependencies:
       tmcp: ^1.20.0-next.0 || ^1.20.0
 
-  '@tmcp/transport-stdio@0.5.0-next.0':
-    resolution: {integrity: sha512-0+U0DPYg97LFVzEK1sEyvvNBX8GSYpehlUKxvjHn9HqFEa9zpMvL/m5nWeJD5zxra+kOKllHeRAw7eyZK/Szew==}
+  '@tmcp/transport-stdio@0.5.0':
+    resolution: {integrity: sha512-1NZsGDveDraa/KWsOOn8VybPn5PbYJi5hRWuIRUKIX7joa3Lx7tSf+0EeXwzG1OyPlsEeTNagBWpBpvpfh5lpw==}
     peerDependencies:
       tmcp: ^1.20.0-next.0 || ^1.20.0
 
@@ -4324,8 +4324,8 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
-  tmcp@1.20.0-next.2:
-    resolution: {integrity: sha512-q2idHdSvQiVwVO+CaBFNeH2jpZQ6dyH5LufH7b+eGD9TT0o5yf79R0/TFpUcvaCAoFVxnGeXOZXJhAFU54IIzw==}
+  tmcp@1.20.0:
+    resolution: {integrity: sha512-dcDximKQBGqLP/aEAVA26HcWRHhKipstg1w0fbDDJ0HcFZ6lolLU1YYmStYEn/73f534i7WrDNcjRfRYdV9CoA==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -6306,34 +6306,34 @@ snapshots:
       vite: 7.3.1(@types/node@24.10.9)(yaml@2.9.0)
       vitefu: 1.1.1(vite@7.3.1(@types/node@24.10.9)(yaml@2.9.0))
 
-  '@tmcp/adapter-valibot@0.1.5(tmcp@1.20.0-next.2(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.20.0(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.9.3))
-      tmcp: 1.20.0-next.2(typescript@5.9.3)
+      tmcp: 1.20.0(typescript@5.9.3)
       valibot: 1.2.0(typescript@5.9.3)
 
-  '@tmcp/session-manager@0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
+  '@tmcp/session-manager@0.3.0(tmcp@1.20.0(typescript@5.9.3))':
     dependencies:
       json-rpc-2.0: 1.7.1
-      tmcp: 1.20.0-next.2(typescript@5.9.3)
+      tmcp: 1.20.0(typescript@5.9.3)
 
-  '@tmcp/transport-http@0.9.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
+  '@tmcp/transport-http@0.9.0(tmcp@1.20.0(typescript@5.9.3))':
     dependencies:
-      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
+      '@tmcp/session-manager': 0.3.0(tmcp@1.20.0(typescript@5.9.3))
       esm-env: 1.2.2
-      tmcp: 1.20.0-next.2(typescript@5.9.3)
+      tmcp: 1.20.0(typescript@5.9.3)
 
-  '@tmcp/transport-in-memory@0.1.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
+  '@tmcp/transport-in-memory@0.1.0(tmcp@1.20.0(typescript@5.9.3))':
     dependencies:
-      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
+      '@tmcp/session-manager': 0.3.0(tmcp@1.20.0(typescript@5.9.3))
       json-rpc-2.0: 1.7.1
-      tmcp: 1.20.0-next.2(typescript@5.9.3)
+      tmcp: 1.20.0(typescript@5.9.3)
 
-  '@tmcp/transport-stdio@0.5.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))':
+  '@tmcp/transport-stdio@0.5.0(tmcp@1.20.0(typescript@5.9.3))':
     dependencies:
-      '@tmcp/session-manager': 0.3.0-next.0(tmcp@1.20.0-next.2(typescript@5.9.3))
-      tmcp: 1.20.0-next.2(typescript@5.9.3)
+      '@tmcp/session-manager': 0.3.0(tmcp@1.20.0(typescript@5.9.3))
+      tmcp: 1.20.0(typescript@5.9.3)
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -8736,7 +8736,7 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
-  tmcp@1.20.0-next.2(typescript@5.9.3):
+  tmcp@1.20.0(typescript@5.9.3):
     dependencies:
       '@standard-schema/spec': 1.1.0
       json-rpc-2.0: 1.7.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,7 +40,7 @@ catalogs:
     '@tmcp/transport-http': 0.9.0-next.0
     '@tmcp/transport-in-memory': 0.1.0-next.0
     '@tmcp/transport-stdio': 0.5.0-next.0
-    tmcp: 1.20.0-next.1
+    tmcp: 1.20.0-next.2
   tooling:
     '@changesets/changelog-github': 1.0.0-next.6
     '@changesets/cli': ^2.29.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,10 +37,10 @@ catalogs:
     svelte-check: ^4.0.0
   tmcp:
     '@tmcp/adapter-valibot': ^0.1.5
-    '@tmcp/transport-http': 0.9.0-next.0
-    '@tmcp/transport-in-memory': 0.1.0-next.0
-    '@tmcp/transport-stdio': 0.5.0-next.0
-    tmcp: 1.20.0-next.2
+    '@tmcp/transport-http': ^0.9.0
+    '@tmcp/transport-in-memory': ^0.1.0
+    '@tmcp/transport-stdio': ^0.5.0
+    tmcp: ^1.20.0
   tooling:
     '@changesets/changelog-github': 1.0.0-next.6
     '@changesets/cli': ^2.29.7


### PR DESCRIPTION
This adds a simple track for the `discover` event so we get a sense of how many new protocols we get and which clients are using it.